### PR TITLE
Feat/22 로그 조회 기능 구현

### DIFF
--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +30,7 @@ public class LogController {
                                                                               @RequestParam(required = false) AuthMethod authMethod,
                                                                               @RequestParam(defaultValue = "0") int page,
                                                                               @RequestParam(defaultValue = "7") int size){
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "accessTime"));
         Page<AccessLogResponse> response = logService.findAccessLogs(startTime, endTime, identifier, name, authMethod, pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.<Page<AccessLogResponse>>builder().result(response).success(true).code(200).message("출입 로그 목록을 성공적으로 조회했습니다.").build());
@@ -48,7 +49,7 @@ public class LogController {
                                                                           @RequestParam(required = false) AuthMethod authMethod,
                                                                           @RequestParam(defaultValue = "0") int page,
                                                                           @RequestParam(defaultValue = "7") int size){
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "accessTime"));
         Page<FailLogResponse> response = logService.findFailLogs(startTime, endTime, authMethod, pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.<Page<FailLogResponse>>builder().result(response).success(true).code(200).message("인증 실패 로그 목록을 성공적으로 조회했습니다.").build());

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
@@ -1,11 +1,56 @@
 package com.deepnyangning.capstonebe.domain.access.controller;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
+import com.deepnyangning.capstonebe.domain.access.dto.FailLogResponse;
+import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
 import com.deepnyangning.capstonebe.domain.access.service.LogService;
+import com.deepnyangning.capstonebe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin/logs")
 public class LogController {
     private final LogService logService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<AccessLogResponse>>> getAccessLogs(@RequestParam(required = false) LocalDateTime startTime,
+                                                                              @RequestParam(required = false) LocalDateTime endTime,
+                                                                              @RequestParam(required = false) String identifier,
+                                                                              @RequestParam(required = false) String name,
+                                                                              @RequestParam(required = false) AuthMethod authMethod,
+                                                                              @RequestParam(defaultValue = "0") int page,
+                                                                              @RequestParam(defaultValue = "7") int size){
+        Pageable pageable = PageRequest.of(page, size);
+        Page<AccessLogResponse> response = logService.findAccessLogs(startTime, endTime, identifier, name, authMethod, pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.<Page<AccessLogResponse>>builder().result(response).success(true).code(200).message("출입 로그 목록을 성공적으로 조회했습니다.").build());
+    }
+
+    @GetMapping("/{logId}")
+    public ResponseEntity<ApiResponse<AccessLogResponse>> getAccessLog(@PathVariable Long logId){
+        AccessLogResponse response = logService.findAccessLog(logId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.<AccessLogResponse>builder().result(response).success(true).code(200).message("출입 로그 상세 정보를 성공적으로 조회했습니다.").build());
+    }
+
+    @GetMapping("/failure")
+    public ResponseEntity<ApiResponse<Page<FailLogResponse>>> getFailLogs(@RequestParam(required = false) LocalDateTime startTime,
+                                                                          @RequestParam(required = false) LocalDateTime endTime,
+                                                                          @RequestParam(required = false) AuthMethod authMethod,
+                                                                          @RequestParam(defaultValue = "0") int page,
+                                                                          @RequestParam(defaultValue = "7") int size){
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FailLogResponse> response = logService.findFailLogs(startTime, endTime, authMethod, pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.<Page<FailLogResponse>>builder().result(response).success(true).code(200).message("인증 실패 로그 목록을 성공적으로 조회했습니다.").build());
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogResponse.java
@@ -1,0 +1,26 @@
+package com.deepnyangning.capstonebe.domain.access.dto;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
+import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessLogResponse {
+    private Long id;
+
+    private AccessLogUserInfo userInfo;
+
+    private AccessType accessType;
+
+    private AuthMethod authMethod;
+
+    private LocalDateTime accessTime;
+
+    private float similarity;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogUserInfo.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogUserInfo.java
@@ -1,0 +1,19 @@
+package com.deepnyangning.capstonebe.domain.access.dto;
+
+import com.deepnyangning.capstonebe.domain.user.entity.Role;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessLogUserInfo {
+    private String identifier;
+
+    private String name;
+
+    private Role role;
+
+    private boolean active;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/FailLogResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/FailLogResponse.java
@@ -1,0 +1,21 @@
+package com.deepnyangning.capstonebe.domain.access.dto;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FailLogResponse {
+    private Long id;
+
+    private AuthMethod authMethod;
+
+    private LocalDateTime accessTime;
+
+    private Float similarity;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
@@ -1,0 +1,12 @@
+package com.deepnyangning.capstonebe.domain.access.mapper;
+
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
+import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface AccessLogMapper {
+    @Mapping(target = "userInfo", ignore = true)
+    AccessLogResponse toResponseDto(AccessLog accessLog);
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/FailLogMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/FailLogMapper.java
@@ -1,0 +1,10 @@
+package com.deepnyangning.capstonebe.domain.access.mapper;
+
+import com.deepnyangning.capstonebe.domain.access.dto.FailLogResponse;
+import com.deepnyangning.capstonebe.domain.access.entity.FailLog;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface FailLogMapper {
+    FailLogResponse toResponseDto(FailLog failLog);
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/AccessLogRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/AccessLogRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 @Repository
 public interface AccessLogRepository extends JpaRepository<AccessLog, Long>, JpaSpecificationExecutor<AccessLog> {
+    int deleteByAccessTimeBefore(LocalDateTime before);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/AccessLogRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/AccessLogRepository.java
@@ -2,8 +2,9 @@ package com.deepnyangning.capstonebe.domain.access.repository;
 
 import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AccessLogRepository extends JpaRepository<AccessLog, Long> {
+public interface AccessLogRepository extends JpaRepository<AccessLog, Long>, JpaSpecificationExecutor<AccessLog> {
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/FailLogRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/FailLogRepository.java
@@ -2,8 +2,9 @@ package com.deepnyangning.capstonebe.domain.access.repository;
 
 import com.deepnyangning.capstonebe.domain.access.entity.FailLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FailLogRepository extends JpaRepository<FailLog, Long> {
+public interface FailLogRepository extends JpaRepository<FailLog, Long>, JpaSpecificationExecutor<FailLog> {
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/FailLogRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/repository/FailLogRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 @Repository
 public interface FailLogRepository extends JpaRepository<FailLog, Long>, JpaSpecificationExecutor<FailLog> {
+    int deleteByAccessTimeBefore(LocalDateTime before);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogCleanupService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogCleanupService.java
@@ -1,0 +1,29 @@
+package com.deepnyangning.capstonebe.domain.access.service;
+
+import com.deepnyangning.capstonebe.domain.access.repository.AccessLogRepository;
+import com.deepnyangning.capstonebe.domain.access.repository.FailLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogCleanupService {
+    private final AccessLogRepository accessLogRepository;
+    private final FailLogRepository failLogRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시에 실행
+    public void cleanOldLogs() {
+        LocalDateTime before = LocalDateTime.now().minusDays(7);
+        int deletedAccess = accessLogRepository.deleteByAccessTimeBefore(before);
+        int deletedFail = failLogRepository.deleteByAccessTimeBefore(before);
+
+        log.info("로그 정리 완료: AccessLog {}건, FailLog {}건이 삭제되었습니다.", deletedAccess, deletedFail);
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
@@ -1,18 +1,31 @@
 package com.deepnyangning.capstonebe.domain.access.service;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
+import com.deepnyangning.capstonebe.domain.access.dto.FailLogResponse;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
 import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
 import com.deepnyangning.capstonebe.domain.access.entity.FailLog;
+import com.deepnyangning.capstonebe.domain.access.mapper.AccessLogMapper;
+import com.deepnyangning.capstonebe.domain.access.mapper.FailLogMapper;
 import com.deepnyangning.capstonebe.domain.access.repository.AccessLogRepository;
 import com.deepnyangning.capstonebe.domain.access.repository.FailLogRepository;
+import com.deepnyangning.capstonebe.domain.access.specification.AccessLogSpecification;
+import com.deepnyangning.capstonebe.domain.access.specification.FailLogSpecification;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.mapper.UserMapper;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -20,6 +33,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class LogService {
     private final AccessLogRepository accessLogRepository;
     private final FailLogRepository failLogRepository;
+    private final UserMapper userMapper;
+    private final AccessLogMapper accessLogMapper;
+    private final FailLogMapper failLogMapper;
 
     @Transactional
     public void saveAccessLog(User user, AuthMethod authMethod, AccessType accessType, Float similarity){
@@ -47,5 +63,27 @@ public class LogService {
         String message = String.format("출입 인증 실패 - authMethod: %s, error: %s",
                 authMethod, errorCode.name());
         log.warn(message);
+    }
+
+    public Page<AccessLogResponse> findAccessLogs(LocalDateTime startTime, LocalDateTime endTime,
+                                                  String identifier, String name, AuthMethod authMethod, Pageable pageable){
+        Specification<AccessLog> spec = AccessLogSpecification.withFilters(startTime, endTime, identifier, name, authMethod);
+        return accessLogRepository.findAll(spec, pageable).map(this::toAccessLogResponse);
+    }
+
+    public AccessLogResponse findAccessLog(Long logId){
+        return toAccessLogResponse(accessLogRepository.findById(logId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ACCESS_LOG_NOT_FOUND)));
+    }
+
+    public Page<FailLogResponse> findFailLogs(LocalDateTime startTime, LocalDateTime endTime, AuthMethod authMethod, Pageable pageable){
+        Specification<FailLog> spec = FailLogSpecification.withFilters(startTime, endTime, authMethod);
+        return failLogRepository.findAll(spec, pageable).map(failLogMapper::toResponseDto);
+    }
+
+    private AccessLogResponse toAccessLogResponse(AccessLog accessLog){
+        AccessLogResponse dto = accessLogMapper.toResponseDto(accessLog);
+        dto.setUserInfo(userMapper.toAccessLogUserInfo(accessLog.getUser()));
+        return dto;
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/specification/AccessLogSpecification.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/specification/AccessLogSpecification.java
@@ -1,0 +1,68 @@
+package com.deepnyangning.capstonebe.domain.access.specification;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
+import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class AccessLogSpecification {
+
+    public static Specification<AccessLog> withFilters(
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            String identifier,
+            String name,
+            AuthMethod authMethod
+    ){
+        return Specification
+                .where(accessTimeBetween(startTime, endTime))
+                .and(hasIdentifierLike(identifier))
+                .and(hasNameLike(name))
+                .and(authMethodEquals(authMethod));
+    }
+
+    // 조회 기간 - accessTime이 특정 범위에 있는지 조회
+    public static Specification<AccessLog> accessTimeBetween(LocalDateTime startTime, LocalDateTime endTime) {
+        return (root, query, cb) -> {
+            if(startTime == null || endTime == null) return null;
+            return cb.between(root.get("accessTime"), startTime, endTime);
+        };
+    }
+
+    // 사용자 - identifier 키워드 검색
+    public static Specification<AccessLog> hasIdentifierLike(String identifier){
+        return (root, query, cb) -> {
+            if(identifier == null || identifier.trim().isEmpty()) return null;
+
+            Join<AccessLog, User> userJoin = root.join("user", JoinType.INNER);
+            String pattern = "%" + identifier.toLowerCase().replace(" ", "") + "%";
+            Expression<String> identifierExpr = cb.lower(cb.function("replace", String.class, userJoin.get("identifier"), cb.literal(" "), cb.literal("")));
+            return cb.like(identifierExpr, pattern);
+        };
+    }
+
+    // 사용자 - name 키워드 검색
+    public static Specification<AccessLog> hasNameLike(String name){
+        return (root, query, cb) -> {
+          if(name == null || name.trim().isEmpty()) return null;
+
+          Join<AccessLog, User> userJoin = root.join("user");
+          String pattern = "%" + name.toLowerCase().replace(" ", "") + "%";
+          Expression<String> nameExpr = cb.lower(cb.function("replace", String.class, userJoin.get("name"), cb.literal(" "), cb.literal("")));
+          return cb.like(nameExpr, pattern);
+        };
+    }
+
+    // 인증 방식 - authMethod가 같은지 판단
+    public static Specification<AccessLog> authMethodEquals(AuthMethod authMethod){
+        return (root, query, cb) -> {
+          if(authMethod == null) return null;
+          return cb.equal(root.get("authMethod"), authMethod);
+        };
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/specification/FailLogSpecification.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/specification/FailLogSpecification.java
@@ -1,0 +1,33 @@
+package com.deepnyangning.capstonebe.domain.access.specification;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
+import com.deepnyangning.capstonebe.domain.access.entity.FailLog;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+
+public class FailLogSpecification {
+
+    public static Specification<FailLog> withFilters(LocalDateTime startTime, LocalDateTime endTime, AuthMethod authMethod){
+        return Specification
+                .where(accessTimeBetween(startTime, endTime))
+                .and(authMethodEquals(authMethod));
+    }
+
+    // 조회 기간 - accessTime이 특정 범위에 있는지 조회
+    public static Specification<FailLog> accessTimeBetween(LocalDateTime startTime, LocalDateTime endTime){
+        return (root, query, cb) -> {
+          if(startTime == null || endTime == null) return null;
+          return cb.between(root.get("accessTime"), startTime, endTime);
+        };
+    }
+
+    // 인증 방식 - authMethod가 같은지 판단
+    public static Specification<FailLog> authMethodEquals(AuthMethod authMethod){
+        return (root, query, cb) -> {
+          if(authMethod == null) return null;
+          return cb.equal(root.get("authMethod"), authMethod);
+        };
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/dto/UserResponse.java
@@ -9,13 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserResponse {
-    private Long id;
-
     private String identifier;
 
     private String name;
-
-    private Role role;
-
-    private boolean active;
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.user.mapper;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogUserInfo;
 import com.deepnyangning.capstonebe.domain.user.dto.UserResponse;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
 import org.mapstruct.Mapper;
@@ -7,4 +8,6 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface UserMapper {
     UserResponse toResponseDto(User user);
+
+    AccessLogUserInfo toAccessLogUserInfo(User user);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     STUDY_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디룸을 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디룸 예약을 찾을 수 없습니다."),
     FACE_ISSUE_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "안면 인식 문제 신고 데이터를 찾을 수 없습니다."),
+    ACCESS_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "출입 로그를 찾을 수 없습니다."),
 
     /*
      * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출


### PR DESCRIPTION
## ❓ 기능 추가 배경

관리자 - 사용자의 출입/실패 로그 조회 기능 구현

## ➕ 추가/변경된 기능

- 출입 로그 전체/상세 조회
- 실패 로그 전체 조회
- 로그는 일주일만 보관하도록 설정
- 조회 필터링 - 조회 기간 / 학번 / 이름 / 인증 방식
- 최신순 정렬

## 🗎 관련 이슈

< #22 >