### PR TITLE
Feat/30 스터디룸 페이징 및 예약 조건 개선

### DIFF
--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomController.java
@@ -4,6 +4,7 @@ import com.deepnyangning.capstonebe.domain.studyroom.dto.StudyRoomResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.mapper.StudyRoomMapper;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomService;
 import com.deepnyangning.capstonebe.global.response.ApiResponse;
+import com.deepnyangning.capstonebe.global.response.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,14 +34,13 @@ public class StudyRoomController {
     }
 
     @GetMapping("/studyrooms")
-    public ResponseEntity<ApiResponse<Page<StudyRoomResponse>>> getAvailableStudyRooms(@RequestParam(required = false) LocalDate date,
+    public ResponseEntity<ApiResponse<CursorPage<StudyRoomResponse>>> getAvailableStudyRooms(@RequestParam(required = false) LocalDate date,
                                                                                        @RequestParam(required = false) @DateTimeFormat(pattern = "HH:mm") LocalTime startTime,
                                                                                        @RequestParam(required = false) @DateTimeFormat(pattern = "HH:mm") LocalTime endTime,
-                                                                                       @RequestParam(defaultValue = "0") int page,
+                                                                                       @RequestParam(required = false) String cursorName,
                                                                                        @RequestParam(defaultValue = "7") int size){
-        Pageable pageable = PageRequest.of(page, size, Sort.Direction.ASC, "name");
-        Page<StudyRoomResponse> studyRoomResponses = studyRoomService.findAvailableStudyRooms(date, startTime, endTime, pageable);
+        List<StudyRoomResponse> response = studyRoomService.findAvailableStudyRooms(date, startTime, endTime, cursorName, size);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<Page<StudyRoomResponse>>builder().result(studyRoomResponses).success(true).code(200).message("스터디룸 조회에 성공했습니다.").build());
+                .body(ApiResponse.<CursorPage<StudyRoomResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("스터디룸 조회에 성공했습니다.").build());
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
@@ -7,14 +7,20 @@ import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUpdate;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomParticipantService;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomReservationService;
 import com.deepnyangning.capstonebe.global.response.ApiResponse;
+import com.deepnyangning.capstonebe.global.response.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 
 @RestController
@@ -40,13 +46,12 @@ public class StudyRoomReservationController {
     }
 
     @GetMapping("/studyrooms/reservations/users/{userId}")
-    public ResponseEntity<ApiResponse<Page<ReservationResponse>>> getStudyRoomReservationsByUser(@PathVariable Long userId,
-                                                                                                 @RequestParam(defaultValue = "0") int page,
-                                                                                                 @RequestParam(defaultValue = "7") int size){
-        Pageable pageable = PageRequest.of(page, size);
-        Page<ReservationResponse> reservationResponses = reservationService.findReservationsByUser(userId, pageable);
+    public ResponseEntity<ApiResponse<CursorPage<ReservationResponse>>> getStudyRoomReservationsByUser(@PathVariable Long userId,
+                                                                                                       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
+                                                                                                       @RequestParam(defaultValue = "7") int size){
+        List<ReservationResponse> response = reservationService.findReservationsByUser(userId, cursorDate, size);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<Page<ReservationResponse>>builder().result(reservationResponses).success(true).code(200).message("사용자별 스터디룸 예약 조회에 성공했습니다.").build());
+                .body(ApiResponse.<CursorPage<ReservationResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("사용자별 스터디룸 예약 조회에 성공했습니다.").build());
     }
 
     @GetMapping("/studyrooms/reservations/{reservationId}")
@@ -71,13 +76,13 @@ public class StudyRoomReservationController {
     }
 
     @GetMapping("/admin/studyrooms/reservations")
-    public ResponseEntity<ApiResponse<Page<ReservationResponse>>> getStudyRoomReservations(@RequestParam(required = false) String name,
-                                                                                           @RequestParam(defaultValue = "0") int page,
-                                                                                           @RequestParam(defaultValue = "7") int size){
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("date"), Sort.Order.desc("startTime")));
-        Page<ReservationResponse> reservationResponses = reservationService.findReservationsByStudyRoomName(name, pageable);
+    public ResponseEntity<ApiResponse<CursorPage<ReservationResponse>>> getStudyRoomReservations(@RequestParam(required = false) String name,
+                                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
+                                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "HH:mm") LocalTime cursorStartTime,
+                                                                                                 @RequestParam(defaultValue = "7") int size){
+        List<ReservationResponse> response = reservationService.findReservationsByStudyRoomName(name, cursorDate, cursorStartTime, size);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<Page<ReservationResponse>>builder().result(reservationResponses).success(true).code(200).message("스터디룸 예약 전체 조회에 성공했습니다.").build());
+                .body(ApiResponse.<CursorPage<ReservationResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("스터디룸 예약 전체 조회에 성공했습니다.").build());
     }
 
     @PutMapping("/admin/studyrooms/reservations/{reservationId}")

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -32,15 +34,18 @@ public class StudyRoomReservationController {
 
 
     @PostMapping("/studyrooms/participants")
-    public ResponseEntity<ApiResponse<Boolean>> getStudyRoomParticipant(@RequestBody ParticipantRequest participantRequest){
-        boolean exists = participantService.existsParticipant(participantRequest);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.<Boolean>builder().result(exists).success(true).code(200).message("존재하는 사용자입니다.").build());
+    public ResponseEntity<ApiResponse<Boolean>> getStudyRoomParticipant(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ParticipantRequest participantRequest){
+        String identifier = userDetails.getUsername();
+        boolean exists = participantService.existsParticipant(identifier, participantRequest);
+        String message = exists ? "존재하는 사용자입니다." : "일치하는 사용자가 존재하지 않습니다.";
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.<Boolean>builder().result(exists).success(true).code(200).message(message).build());
     }
     // participantResponse로 응답하는 거 고려하기
 
     @PostMapping("/studyrooms/reservations")
-    public ResponseEntity<ApiResponse<ReservationResponse>> createStudyRoomReservation(@RequestBody ReservationRequest reservationRequest){
-        ReservationResponse reservationResponse = reservationService.saveReservation(reservationRequest);
+    public ResponseEntity<ApiResponse<ReservationResponse>> createStudyRoomReservation(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ReservationRequest reservationRequest){
+        String identifier = userDetails.getUsername();
+        ReservationResponse reservationResponse = reservationService.saveReservation(identifier, reservationRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.<ReservationResponse>builder().result(reservationResponse).success(true).code(201).message("스터디룸 예약에 성공했습니다.").build());
     }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ParticipantRequest.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ParticipantRequest.java
@@ -2,6 +2,8 @@ package com.deepnyangning.capstonebe.domain.studyroom.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Getter
 @Setter
 @Builder
@@ -11,4 +13,6 @@ public class ParticipantRequest {
     private String identifier;
 
     private String name;
+
+    private LocalDate date;
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomParticipantRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomParticipantRepository.java
@@ -3,9 +3,20 @@ package com.deepnyangning.capstonebe.domain.studyroom.repository;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomParticipant;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
 
 @Repository
 public interface StudyRoomParticipantRepository extends JpaRepository<StudyRoomParticipant, Long> {
-    void deleteByReservation(StudyRoomReservation reservation);
+    @Query("""
+        SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END
+        FROM StudyRoomParticipant p
+        WHERE p.identifier = :identifier
+        AND p.reservation.date = :date
+        AND p.reservation.status != 'CANCELED'
+    """)
+    boolean existsByIdentifierAndDate(@Param("identifier") String identifier, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomRepository.java
@@ -10,25 +10,40 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Repository
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
 
     @Query(value = "SELECT * FROM study_room sr " +
-            "WHERE sr.id NOT IN (" +
+            "WHERE (:cursorName IS NULL OR sr.name > :cursorName) " +
+            "AND sr.id NOT IN (" +
             "SELECT r.study_room_id FROM study_room_reservation r " +
             "WHERE r.date = :date " +
             "AND r.status != 'CANCELED' " +
             "GROUP BY r.study_room_id " +
             "HAVING SUM(TIMESTAMPDIFF(MINUTE, r.start_time, r.end_time)) >= :availableMinutes" +
-            ")", nativeQuery = true)
-    Page<StudyRoom> findAvailableStudyRoomsByDate(@Param("date") LocalDate date,
+            ") ORDER BY sr.name ASC LIMIT :limit", nativeQuery = true)
+    List<StudyRoom> findAvailableStudyRoomsByDate(@Param("date") LocalDate date,
                                                   @Param("availableMinutes") int availableMinutes,
-                                                  Pageable pageable);
+                                                  @Param("cursorName") String cursorName,
+                                                  @Param("limit") int limit);
 
-    @Query("SELECT sr FROM StudyRoom sr WHERE sr.id NOT IN (" +
-            "SELECT r.studyRoom.id FROM StudyRoomReservation r " +
-            "WHERE r.date = :date AND r.endTime > :startTime AND r.startTime < :endTime " +
-            "AND r.status != 'CANCELED')")
-    Page<StudyRoom> findAvailableStudyRooms(@Param("date") LocalDate date, @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime, Pageable pageable);
+    @Query(value = "SELECT * FROM study_room sr " +
+            "WHERE (:cursorName IS NULL OR sr.name > :cursorName) " +
+            "AND sr.id NOT IN ( " +
+            "   SELECT r.study_room_id FROM study_room_reservation r " +
+            "   WHERE r.date = :date " +
+            "   AND r.end_time > :startTime " +
+            "   AND r.start_time < :endTime " +
+            "   AND r.status != 'CANCELED' " +
+            ") " +
+            "ORDER BY sr.name ASC " +
+            "LIMIT :limit", nativeQuery = true)
+    List<StudyRoom> findAvailableStudyRooms(@Param("date") LocalDate date,
+                                            @Param("startTime") LocalTime startTime,
+                                            @Param("endTime") LocalTime endTime,
+                                            @Param("cursorName") String cursorName,
+                                            @Param("limit") int limit);
+
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
@@ -19,9 +19,30 @@ import java.util.List;
 
 @Repository
 public interface StudyRoomReservationRepository extends JpaRepository<StudyRoomReservation, Long> {
-    @Query("SELECT r FROM StudyRoomReservation r WHERE REPLACE(UPPER(r.studyRoom.name), ' ', '') LIKE %:name%")
-    Page<StudyRoomReservation> findStudyRoomReservationsByStudyRoomName(@Param("name") String name, Pageable pageable);
-    Page<StudyRoomReservation> findStudyRoomReservationsByUser(User user, Pageable pageable);
+    @Query(value = """
+        SELECT r.* FROM study_room_reservation r
+        JOIN study_room sr ON r.study_room_id = sr.id
+        WHERE (:name IS NULL OR REPLACE(UPPER(sr.name), ' ', '') LIKE %:name%)
+        AND (
+            :cursorDate IS NULL
+            OR (r.date < :cursorDate OR (r.date = :cursorDate AND r.start_time < :cursorStartTime))
+        )
+        ORDER BY r.date DESC, r.start_time DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<StudyRoomReservation> findByStudyRoomName(@Param("name") String name,
+                                                   @Param("cursorDate") LocalDate cursorDate,
+                                                   @Param("cursorStartTime") LocalTime cursorStartTime,
+                                                   @Param("limit") int limit);
+
+    @Query(value = "SELECT r.* FROM study_room_reservation r " +
+            "WHERE r.user_id = :userId " +
+            "AND (:cursorDate IS NULL OR r.date < :cursorDate) " +
+            "ORDER BY r.date DESC " +
+            "LIMIT :limit", nativeQuery = true)
+    List<StudyRoomReservation> findByUser(@Param("userId") Long userId,
+                                                                         @Param("cursorDate") LocalDate cursorDate,
+                                                                         @Param("limit") int limit);
     List<StudyRoomReservation> findByDateAndEndTimeLessThanEqualAndStatus(LocalDate date, LocalTime time, ReservationStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 @Repository
 public interface StudyRoomReservationRepository extends JpaRepository<StudyRoomReservation, Long> {
+    boolean existsByUserAndDateAndStatusNot(User user, LocalDate date, ReservationStatus status);
+
     @Query(value = """
         SELECT r.* FROM study_room_reservation r
         JOIN study_room sr ON r.study_room_id = sr.id
@@ -41,8 +43,8 @@ public interface StudyRoomReservationRepository extends JpaRepository<StudyRoomR
             "ORDER BY r.date DESC " +
             "LIMIT :limit", nativeQuery = true)
     List<StudyRoomReservation> findByUser(@Param("userId") Long userId,
-                                                                         @Param("cursorDate") LocalDate cursorDate,
-                                                                         @Param("limit") int limit);
+                                          @Param("cursorDate") LocalDate cursorDate,
+                                          @Param("limit") int limit);
     List<StudyRoomReservation> findByDateAndEndTimeLessThanEqualAndStatus(LocalDate date, LocalTime time, ReservationStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomParticipantService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomParticipantService.java
@@ -4,23 +4,23 @@ import com.deepnyangning.capstonebe.domain.studyroom.dto.ParticipantRequest;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomParticipant;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
 import com.deepnyangning.capstonebe.domain.studyroom.mapper.StudyRoomParticipantMapper;
-import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomParticipantRepository;
 import com.deepnyangning.capstonebe.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StudyRoomParticipantService {
-    private final StudyRoomParticipantRepository participantRepository;
+    private final StudyRoomParticipantValidator validator;
     private final StudyRoomParticipantMapper participantMapper;
     private final UserService userService;
 
-    public boolean existsParticipant(ParticipantRequest participantRequest){
+    public boolean existsParticipant(String identifier, ParticipantRequest participantRequest){
+        validator.validateParticipant(identifier, participantRequest);
+
         return userService.existsByIdentifierAndName(participantRequest.getIdentifier(), participantRequest.getName());
     }
 

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomParticipantValidator.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomParticipantValidator.java
@@ -1,0 +1,47 @@
+package com.deepnyangning.capstonebe.domain.studyroom.service;
+
+import com.deepnyangning.capstonebe.domain.studyroom.dto.ParticipantRequest;
+import com.deepnyangning.capstonebe.domain.studyroom.entity.ReservationStatus;
+import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomParticipantRepository;
+import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReservationRepository;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.service.UserService;
+import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class StudyRoomParticipantValidator {
+    private final UserService userService;
+    private final StudyRoomReservationRepository reservationRepository;
+    private final StudyRoomParticipantRepository participantRepository;
+
+    public void validateParticipant(String identifier, ParticipantRequest participantRequest){
+        String targetIdentifier = participantRequest.getIdentifier();
+        LocalDate date = participantRequest.getDate();
+
+        checkSelfParticipation(identifier, targetIdentifier);
+        validateDuplicatedReservationOrParticipation(identifier,date);
+        validateDuplicatedReservationOrParticipation(targetIdentifier,date);
+    }
+
+    public void checkSelfParticipation(String identifier, String participantIdentifier){
+        if(identifier.equals(participantIdentifier)){
+            throw new CustomException(ErrorCode.INVALID_SELF_PARTICIPATION);
+        }
+    }
+
+    public void validateDuplicatedReservationOrParticipation(String identifier, LocalDate date){
+        User user = userService.findByIdentifier(identifier);
+        boolean hasReservation = reservationRepository.existsByUserAndDateAndStatusNot(user, date, ReservationStatus.CANCELED);
+        boolean hasParticipation = participantRepository.existsByIdentifierAndDate(user.getIdentifier(), date);
+
+        if(hasReservation || hasParticipation){
+            throw new CustomException(ErrorCode.ALREADY_RESERVED_ON_DATE);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
@@ -78,20 +78,15 @@ public class StudyRoomReservationService {
         return reservationMapper.toResponseDto(reservation);
     }
 
-    public Page<ReservationResponse> findReservationsByStudyRoomName(String name, Pageable pageable){
-        Page<StudyRoomReservation> reservations;
-        if (name == null || name.trim().isEmpty()) {
-            reservations = reservationRepository.findAll(pageable);
-        } else{
-            reservations = reservationRepository.findStudyRoomReservationsByStudyRoomName(name.toUpperCase().replace(" ", ""), pageable);
-        }
-        return reservations.map(reservationMapper::toResponseDto);
+    public List<ReservationResponse> findReservationsByStudyRoomName(String name, LocalDate cursorDate, LocalTime cursorStartTime, int size) {
+        String formattedName = (name == null || name.isBlank()) ? null : name.toUpperCase().replace(" ", "");
+        List<StudyRoomReservation> reservations = reservationRepository.findByStudyRoomName(formattedName, cursorDate, cursorStartTime, size+1);
+        return reservations.stream().map(reservationMapper::toResponseDto).toList();
     }
 
-    public Page<ReservationResponse> findReservationsByUser(Long userId, Pageable pageable){
-        User user = userService.findById(userId);
-        return reservationRepository.findStudyRoomReservationsByUser(user, pageable)
-                .map(reservationMapper::toResponseDto);
+    public List<ReservationResponse> findReservationsByUser(Long userId, LocalDate cursorDate, int size){
+        return reservationRepository.findByUser(userId, cursorDate, size+1)
+                .stream().map(reservationMapper::toResponseDto).toList();
     }
 
     public ReservationResponse findReservationById(Long id){

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
@@ -4,23 +4,17 @@ import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationRequest;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUpdate;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.ReservationStatus;
-import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomParticipant;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
 import com.deepnyangning.capstonebe.domain.studyroom.mapper.StudyRoomReservationMapper;
 import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReservationRepository;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
-import com.deepnyangning.capstonebe.domain.user.service.UserService;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -31,47 +25,22 @@ public class StudyRoomReservationService {
     private final StudyRoomReservationRepository reservationRepository;
     private final StudyRoomReservationMapper reservationMapper;
     private final StudyRoomService studyRoomService;
-    private final UserService userService;
     private final StudyRoomParticipantService participantService;
-
-    public void validateReservationDuration(LocalTime startTime, LocalTime endTime){
-        long minutes = Duration.between(startTime, endTime).toMinutes();
-        if(minutes != 60 && minutes != 120) {
-            throw new CustomException(ErrorCode.INVALID_RESERVATION_DURATION);
-        }
-    }
-
-    public void validateReservationTimeRange(LocalDate date, LocalTime startTime, LocalTime endTime){
-        DayOfWeek dayOfWeek = date.getDayOfWeek();
-        LocalTime openTime = LocalTime.of(10, 0);
-        LocalTime closeTime = (dayOfWeek == DayOfWeek.SATURDAY) ? LocalTime.of(16, 0) : LocalTime.of(21, 0);
-
-        if(startTime.isBefore(openTime) || endTime.isAfter(closeTime)){
-            throw new CustomException(ErrorCode.INVALID_RESERVATION_TIME);
-        }
-    }
-
-    public void checkTimeConflict(Long studyRoomId, LocalDate date, LocalTime startTime, LocalTime endTime){
-        List<StudyRoomReservation> existedReservations =  reservationRepository.findConflictReservations(studyRoomId, date, startTime, endTime, ReservationStatus.CONFIRMED);
-        if(!existedReservations.isEmpty()){
-            throw new CustomException(ErrorCode.DUPLICATE_RESERVATION);
-        }
-    }
+    private final StudyRoomReservationValidator validator;
 
     @Transactional
-    public ReservationResponse saveReservation(ReservationRequest reservationRequest){
+    public ReservationResponse saveReservation(String identifier, ReservationRequest reservationRequest){
         LocalDate date = reservationRequest.getDate();
         LocalTime startTime = reservationRequest.getStartTime();
         LocalTime endTime = reservationRequest.getEndTime();
         Long studyRoomId = reservationRequest.getStudyRoomId();
+        int participantCnt = reservationRequest.getParticipants().size();
 
-        validateReservationDuration(startTime, endTime);
-        validateReservationTimeRange(date, startTime, endTime);
-        checkTimeConflict(studyRoomId, date, startTime, endTime);
+        User user = validator.validateReservation(identifier, date, startTime, endTime, studyRoomId, participantCnt);
 
         StudyRoomReservation reservation = reservationMapper.toEntity(reservationRequest);
         reservation.setStudyRoom(studyRoomService.findStudyRoomById(studyRoomId));
-        reservation.setUser(userService.findById(reservationRequest.getUserId()));
+        reservation.setUser(user);
         reservation.setStatus(ReservationStatus.CONFIRMED);
         participantService.saveParticipants(reservationRequest.getParticipants(), reservation);
         reservationRepository.save(reservation);

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationValidator.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationValidator.java
@@ -1,0 +1,80 @@
+package com.deepnyangning.capstonebe.domain.studyroom.service;
+
+import com.deepnyangning.capstonebe.domain.studyroom.entity.ReservationStatus;
+import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoom;
+import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
+import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomParticipantRepository;
+import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReservationRepository;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.service.UserService;
+import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StudyRoomReservationValidator {
+    private final StudyRoomParticipantRepository participantRepository;
+    private final StudyRoomReservationRepository reservationRepository;
+    private final StudyRoomService studyRoomService;
+    private final UserService userService;
+
+    public User validateReservation(String identifier, LocalDate date, LocalTime startTime, LocalTime endTime, Long studyRoomId, int participantCnt) {
+        User user = validateDuplicatedReservationOrParticipation(identifier, date);
+        validateReservationDuration(startTime, endTime);
+        validateReservationTimeRange(date, startTime, endTime);
+        validateMinParticipants(studyRoomId, participantCnt);
+        checkTimeConflict(studyRoomId, date, startTime, endTime);
+        return user;
+    }
+
+    public void validateReservationDuration(LocalTime startTime, LocalTime endTime){
+        long minutes = Duration.between(startTime, endTime).toMinutes();
+        if(minutes != 60 && minutes != 120) {
+            throw new CustomException(ErrorCode.INVALID_RESERVATION_DURATION);
+        }
+    }
+
+    public void validateReservationTimeRange(LocalDate date, LocalTime startTime, LocalTime endTime){
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        LocalTime openTime = LocalTime.of(10, 0);
+        LocalTime closeTime = (dayOfWeek == DayOfWeek.SATURDAY) ? LocalTime.of(16, 0) : LocalTime.of(21, 0);
+
+        if(startTime.isBefore(openTime) || endTime.isAfter(closeTime)){
+            throw new CustomException(ErrorCode.INVALID_RESERVATION_TIME);
+        }
+    }
+
+    public void checkTimeConflict(Long studyRoomId, LocalDate date, LocalTime startTime, LocalTime endTime){
+        List<StudyRoomReservation> existedReservations =  reservationRepository.findConflictReservations(studyRoomId, date, startTime, endTime, ReservationStatus.CONFIRMED);
+        if(!existedReservations.isEmpty()){
+            throw new CustomException(ErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    public void validateMinParticipants(Long studyRoomId, int participantCnt){
+        StudyRoom studyRoom = studyRoomService.findStudyRoomById(studyRoomId);
+        if (participantCnt < studyRoom.getMinCapacity() - 1){
+            throw new CustomException(ErrorCode.INVALID_STUDY_ROOM_PARTICIPANTS,
+                    String.format("최소 동반 이용자는 %d명입니다.", studyRoom.getMinCapacity() - 1));
+        }
+    }
+
+    public User validateDuplicatedReservationOrParticipation(String identifier, LocalDate date){
+        User user = userService.findByIdentifier(identifier);
+        boolean hasReservation = reservationRepository.existsByUserAndDateAndStatusNot(user, date, ReservationStatus.CANCELED);
+        boolean hasParticipation = participantRepository.existsByIdentifierAndDate(user.getIdentifier(), date);
+
+        if(hasReservation || hasParticipation){
+            throw new CustomException(ErrorCode.ALREADY_RESERVED_ON_DATE);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 
 @Service
@@ -27,7 +28,8 @@ public class StudyRoomService {
                 .orElseThrow(() -> new CustomException(ErrorCode.STUDY_ROOM_NOT_FOUND));
     }
 
-    public Page<StudyRoomResponse> findAvailableStudyRooms(LocalDate date, LocalTime startTime, LocalTime endTime, Pageable pageable){
+    public List<StudyRoomResponse> findAvailableStudyRooms(LocalDate date, LocalTime startTime, LocalTime endTime, String cursorName, int size){
+        List<StudyRoom> studyRooms;
         if (date != null && startTime == null && endTime == null){
             int availableMinutes;
             DayOfWeek dayOfWeek = date.getDayOfWeek();
@@ -37,10 +39,11 @@ public class StudyRoomService {
             else{
                 availableMinutes = 660;
             }
-            return studyRoomRepository.findAvailableStudyRoomsByDate(date, availableMinutes, pageable)
-                    .map(studyRoomMapper::toResponseDto);
+            studyRooms =  studyRoomRepository.findAvailableStudyRoomsByDate(date, availableMinutes, cursorName, size+1);
         }
-        return studyRoomRepository.findAvailableStudyRooms(date, startTime, endTime, pageable)
-                .map(studyRoomMapper::toResponseDto);
+        else {
+            studyRooms = studyRoomRepository.findAvailableStudyRooms(date, startTime, endTime, cursorName, size+1);
+        }
+        return studyRooms.stream().map(studyRoomMapper::toResponseDto).toList();
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.global.code;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,9 @@ public enum ErrorCode {
     INSUFFICIENT_SIMILARITY(HttpStatus.BAD_REQUEST, "안면 인식 유사도가 충분하지 않습니다."),
     INVALID_QR_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 QR 코드입니다."),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "새 비밀번호는 기존 비밀번호와 다르게 설정해야 합니다."),
+    INVALID_STUDY_ROOM_PARTICIPANTS(HttpStatus.BAD_REQUEST, "동반 이용자 수가 부족합니다."),
+    ALREADY_RESERVED_ON_DATE(HttpStatus.BAD_REQUEST, "해당 날짜에 이미 예약된 스터디룸이 존재합니다."),
+    INVALID_SELF_PARTICIPATION(HttpStatus.BAD_REQUEST, "본인의 학번으로는 신청할 수 없습니다."),
 
     /*
      * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청

--- a/src/main/java/com/deepnyangning/capstonebe/global/exception/CustomException.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/exception/CustomException.java
@@ -6,9 +6,17 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
+    private final String customMessage;
 
     public CustomException(ErrorCode errorCode){
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+        this.customMessage = null;
+    }
+
+    public CustomException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/exception/GlobalExceptionHandler.java
@@ -17,11 +17,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     protected final ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         log.error("Exception 발생: {}", e.getErrorCode().getMessage(), e);
+        String message = e.getCustomMessage() != null ? e.getCustomMessage() : e.getErrorCode().getMessage();
+
 
         ErrorResponse response = ErrorResponse.builder()
                 .code(e.getErrorCode().getHttpStatus().value())
                 .error(e.getErrorCode().getHttpStatus().name())
-                .message(e.getErrorCode().getMessage())
+                .message(message)
                 .build();
 
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);

--- a/src/main/java/com/deepnyangning/capstonebe/global/response/CursorPage.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/response/CursorPage.java
@@ -1,0 +1,19 @@
+package com.deepnyangning.capstonebe.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CursorPage<T> {
+    private List<T> content;
+    private boolean hasNext;
+
+    public static <T> CursorPage<T> of(List<T> list, int size) {
+        boolean hasNext = list.size() > size;
+        List<T> content = hasNext ? list.subList(0, size) : list;
+        return new CursorPage<>(content, hasNext);
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

스터디룸 페이징 처리 변경 및 예약, 동반 이용자 관련 검증 추가

## ➕ 추가/변경된 기능

- 페이지네이션 cursor 기반으로 변경
- 최소 동반 이용자 인원 검증 - (minCapacity - 1) 이상
- 동일 인물의 동일 날짜 예약 제한
- 본인 학번으로 동반 이용자 등록 제한
- 동반 이용자 중 이미 같은 날짜 예약한 사용자 제한
- 검증 로직 validator 클래스로 분리

## 🗎 관련 이슈

< #30 >