### PR TITLE
Feat/32 얼굴 등록 기능 구현

### DIFF
--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/controller/FaceDataController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/controller/FaceDataController.java
@@ -1,11 +1,31 @@
 package com.deepnyangning.capstonebe.domain.face.controller;
 
 import com.deepnyangning.capstonebe.domain.face.service.FaceDataService;
+import com.deepnyangning.capstonebe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/faces")
 public class FaceDataController {
     private final FaceDataService faceDataService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> registerFace(@AuthenticationPrincipal UserDetails userDetails,
+                                                          @RequestParam("file") MultipartFile file){
+        String identifier = userDetails.getUsername();
+        faceDataService.registerFace(file, identifier);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.<Void>builder().success(true).code(201).message("얼굴 등록에 성공했습니다.").build());
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/entity/FaceData.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/entity/FaceData.java
@@ -20,11 +20,5 @@ public class FaceData extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Lob
-    private byte[] faceVector;
-
-    @Enumerated(EnumType.STRING)
-    private TrainingMethod trainingMethod;
-
-    private float accuracy;
+    private String status; // SUCCESS or FAIL
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
@@ -1,11 +1,40 @@
 package com.deepnyangning.capstonebe.domain.face.service;
 
+import com.deepnyangning.capstonebe.domain.face.entity.FaceData;
 import com.deepnyangning.capstonebe.domain.face.repository.FaceDataRepository;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.service.UserService;
+import com.deepnyangning.capstonebe.external.ai.AiServerClient;
+import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class FaceDataService {
+    private final AiServerClient aiServerClient;
     private final FaceDataRepository faceDataRepository;
+    private final UserService userService;
+    private final FileValidator fileValidator;
+
+    @Transactional
+    public void registerFace(MultipartFile file, String identifier){
+        fileValidator.validateVideo(file);
+
+        User user = userService.findByIdentifier(identifier);
+
+        String aiServerResponse = aiServerClient.sendFaceDataToAiServer(file, identifier);
+
+        FaceData faceData = FaceData.builder()
+                .user(user)
+                .status(aiServerResponse)
+                .build();
+        faceDataRepository.save(faceData);
+        if("FAIL".equals(aiServerResponse)){
+            throw new CustomException(ErrorCode.FACE_REGISTRATION_FAILED);
+        }
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FileValidator.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FileValidator.java
@@ -1,0 +1,23 @@
+package com.deepnyangning.capstonebe.domain.face.service;
+
+import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class FileValidator {
+    private static long MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100MB
+
+    public void validateVideo(MultipartFile file){
+        if(file.isEmpty()){
+            throw new CustomException(ErrorCode.INVALID_VIDEO_FILE, "영상이 비어 있습니다.");
+        }
+        if (file.getContentType() == null || !file.getContentType().startsWith("video/")) {
+            throw new CustomException(ErrorCode.INVALID_VIDEO_FILE, "유효한 영상 파일이 아닙니다.");
+        }
+        if (file.getSize() > MAX_VIDEO_SIZE) {
+            throw new CustomException(ErrorCode.INVALID_VIDEO_FILE, "영상 파일 크기가 너무 큽니다.");
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
@@ -1,0 +1,41 @@
+package com.deepnyangning.capstonebe.external.ai;
+
+import com.deepnyangning.capstonebe.global.code.ErrorCode;
+import com.deepnyangning.capstonebe.global.exception.CustomException;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class AiServerClient {
+    private static final String AI_SERVER_URL = ""; // 추후 작성
+
+    public String sendFaceDataToAiServer(MultipartFile file, String identifier){
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", new ByteArrayResource(file.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return file.getOriginalFilename(); // null 방지
+                }
+            });
+            body.add("identifier", identifier);
+
+            HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.exchange(AI_SERVER_URL, HttpMethod.POST, request, String.class);
+
+            return response.getStatusCode().is2xxSuccessful() ? "SUCCESS" : "FAIL";
+        } catch (Exception e){
+            throw new CustomException(ErrorCode.AI_SERVER_COMMUNICATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     INVALID_STUDY_ROOM_PARTICIPANTS(HttpStatus.BAD_REQUEST, "동반 이용자 수가 부족합니다."),
     ALREADY_RESERVED_ON_DATE(HttpStatus.BAD_REQUEST, "해당 날짜에 이미 예약된 스터디룸이 존재합니다."),
     INVALID_SELF_PARTICIPATION(HttpStatus.BAD_REQUEST, "본인의 학번으로는 신청할 수 없습니다."),
+    FACE_REGISTRATION_FAILED(HttpStatus.BAD_REQUEST, "얼굴 등록에 실패했습니다."),
+    INVALID_VIDEO_FILE(HttpStatus.BAD_REQUEST, "유효하지 않은 영상 파일입니다."),
 
     /*
      * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청
@@ -64,7 +66,8 @@ public enum ErrorCode {
     /*
      * 503 SERVICE_UNAVAILABLE: 서비스 이용 불가
      */
-    REDIS_OPERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Redis 작업에 실패했습니다.");
+    REDIS_OPERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Redis 작업에 실패했습니다."),
+    AI_SERVER_COMMUNICATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서버와의 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## ❓ 기능 추가 배경

영상 기반의 얼굴 등록 처리 로직 구현

## ➕ 추가/변경된 기능

- FaceData 엔티티 구조 수정
- 영상 파일 수신 및 사용자 인증 처리
- ai 서버로 학번 + 영상 전송
- 등록 결과 db에 저장
- 예외 처리 및 실패 응답 핸들링

## 🗎 관련 이슈

< #32 >