### PR TITLE
Feat/39 푸시 알림 기능 구현

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -115,3 +115,15 @@ jobs:
             docker-compose down
             docker system prune -f --volumes
             docker-compose up -d --build
+
+      # 12. EC2에서 app.jar 위치 이동 (명시적 복사)
+      - name: Move app.jar to correct path
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          script: |
+            cp ${{ secrets.DEPLOY_PATH }}/app.jar /home/ubuntu/services/app.jar
+            cp ${{ secrets.DEPLOY_PATH }}/application.yml /home/ubuntu/services/application.yml
+            echo "Files moved to /home/ubuntu/services"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -70,6 +70,7 @@ jobs:
           target: "${{ secrets.DEPLOY_PATH }}"
           overwrite: true
           debug: true
+          strip_components: 2
 
       # 10. application.yml 전송
       - name: Copy application.yml to EC2

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,8 +1,10 @@
 name: Dev Deploy CD
 
 on:
-  push:
-    branches: [ dev ]
+  pull_request:
+    branches:
+      - dev
+    types: [opened, synchronize, reopened]
 
 jobs:
   deploy:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -33,47 +33,45 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 4. 실행 권한 부여
+      # 4. gradlew 실행 권한 부여
       - name: Grant execute permission to gradlew
         run: chmod +x ./gradlew
 
-      # 5. Gradle로 빌드 수행
-      - name: Build with Gradle
-        run: |
-          ./gradlew clean build -x test
-          ls -la build/libs/
-          [ -f "build/libs/Capstone-BE-0.0.1-SNAPSHOT.jar" ] || { echo "JAR not found!"; exit 1; }
-          echo "Build from commit: $GITHUB_SHA"
+      # 5. 고유 태그 생성 (커밋 SHA 앞 7자리)
+      - name: Generate Unique Tag
+        id: generate_tag
+        run: echo "tag=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
 
-      # 6. JAR 이름 변경
-      - name: Rename JAR to app.jar
-        run: |
-          mv build/libs/Capstone-BE-0.0.1-SNAPSHOT.jar build/libs/app.jar
-          ls -la build/libs/
-          [ -f "build/libs/app.jar" ] || { echo "app.jar not found!"; exit 1; }
+      # 6. Gradle로 빌드 수행
+      - name: Build JAR
+        run: ./gradlew clean bootJar -x test
 
-      # 7. application.yml 생성
+      # 7. 빌드된 JAR 이름 변경
+      - name: Rename JAR with tag
+        run: |
+          TAG=${{ steps.generate_tag.outputs.tag }}
+          mv build/libs/Capstone-BE-0.0.1-SNAPSHOT.jar build/libs/app-${TAG}.jar
+          ls -la build/libs/
+
+      # 8. application.yml 생성
       - name: Generate application.yml
         run: |
           echo "${{ secrets.APPLICATION_YML_CONTENT }}" > application.yml
           ls -la application.yml
 
-      # 8. app.jar 전송
-      - name: Copy app.jar to EC2
+      # 9. JAR 전송
+      - name: Copy JAR to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
-          source: "build/libs/app.jar"
+          source: "build/libs/app-${{ steps.generate_tag.outputs.tag }}.jar"
           target: "${{ secrets.DEPLOY_PATH }}"
           overwrite: true
           debug: true
-          timeout: 60s
-          command_timeout: 15m
-          strip_components: 1
 
-      # 9. application.yml 전송
+      # 10. application.yml 전송
       - name: Copy application.yml to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -84,25 +82,9 @@ jobs:
           target: "${{ secrets.DEPLOY_PATH }}"
           overwrite: true
           debug: true
-          timeout: 60s
-          command_timeout: 15m
 
-      # 10. EC2에서 파일 전송 확인
-      - name: Verify files on EC2
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.KEY }}
-          script: |
-            echo "Checking files in ${{ secrets.DEPLOY_PATH }}..."
-            ls -la ${{ secrets.DEPLOY_PATH }}
-            [ -f "${{ secrets.DEPLOY_PATH }}/app.jar" ] || { echo "app.jar not found!"; exit 1; }
-            [ -f "${{ secrets.DEPLOY_PATH }}/application.yml" ] || { echo "application.yml not found!"; exit 1; }
-            echo "Files successfully transferred."
-
-      # 11. EC2에서 Docker Compose 재시작
-      - name: Restart Docker Compose
+      # 11. EC2에서 파일 존재 확인 및 app.jar로 복사
+      - name: Prepare files on EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.HOST }}
@@ -110,20 +92,23 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             cd ${{ secrets.DEPLOY_PATH }}
-            echo "Current directory: $(pwd)"
+            echo "Checking uploaded files..."
             ls -la
-            docker-compose down
-            docker system prune -f --volumes
-            docker-compose up -d --build
+            TAG=${{ steps.generate_tag.outputs.tag }}
+            cp app-${TAG}.jar /home/ubuntu/services/app.jar
+            cp application.yml /home/ubuntu/services/application.yml
+            echo "Files moved to /home/ubuntu/services"
 
-      # 12. EC2에서 app.jar 위치 이동 (명시적 복사)
-      - name: Move app.jar to correct path
+      # 12. Docker Compose 재시작
+      - name: Restart Docker Compose
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           script: |
-            cp ${{ secrets.DEPLOY_PATH }}/app.jar /home/ubuntu/services/app.jar
-            cp ${{ secrets.DEPLOY_PATH }}/application.yml /home/ubuntu/services/application.yml
-            echo "Files moved to /home/ubuntu/services"
+            cd /home/ubuntu/services
+            echo "Restarting docker-compose..."
+            docker-compose down
+            docker system prune -f --volumes
+            docker-compose up -d --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,16 @@ jobs:
               secret-key: ${{ secrets.JWT_SECRET_KEY }}
               access-exp-time: ${{ secrets.ACCESS_EXP_TIME }}
               refresh-exp-time: ${{ secrets.REFRESH_EXP_TIME }}
+          
+            firebase:
+              project-id: capstone-dnn-bfa9f
+              key-path: ./src/main/resources/firebase/serviceAccountKey.json
             EOF
+
+      - name: Decode Firebase service account key
+        run: |
+          mkdir -p src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_KEY_BASE64 }}" | base64 --decode > src/main/resources/firebase/serviceAccountKey.json
 
       - name: Run Tests with H2
         run: ./gradlew test -Dspring.profiles.active=test

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ application.yml
 application-dev.yml
 application-prod.yml
 application-test.yml
+
+### Firebase Admin Key ###
+src/main/resources/firebase/serviceAccountKey.json

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 	testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
+
+	// firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/event/AccessCompletedEvent.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/event/AccessCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.deepnyangning.capstonebe.domain.access.event;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AccessCompletedEvent {
+    private final User user;
+    private final AccessType accessType;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/event/AccessEventListener.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/event/AccessEventListener.java
@@ -1,0 +1,31 @@
+package com.deepnyangning.capstonebe.domain.access.event;
+
+import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessEventListener {
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onAccessCompleted(AccessCompletedEvent event){
+        try{
+            User user = event.getUser();
+            AccessType accessType = event.getAccessType();
+            notificationService.sendPush(user,
+                    accessType == AccessType.ENTRY ? PushType.ENTRY_SUCCESS : PushType.EXIT_SUCCESS);
+            log.info("출입 알림 전송 완료: identifier={}, accessType={}", user.getIdentifier(), accessType);
+        } catch (Exception e){
+            log.warn("출입 알림 전송 실패: identifier={}, accessType={}", event.getUser().getIdentifier(), event.getAccessType(), e);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
@@ -3,9 +3,8 @@ package com.deepnyangning.capstonebe.domain.access.service;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.FaceAccessRequest;
 import com.deepnyangning.capstonebe.domain.access.dto.QrAccessRequest;
-import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
 import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
-import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.access.event.AccessCompletedEvent;
 import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
 import com.deepnyangning.capstonebe.domain.qr.service.QRService;
 import com.deepnyangning.capstonebe.domain.statistics.service.StatisticsService;
@@ -15,10 +14,9 @@ import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -29,6 +27,7 @@ public class AccessService {
     private final QRService qrService;
     private final StatisticsService statisticsService;
     private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public AccessResponse processQrAccess(QrAccessRequest request){
@@ -50,7 +49,7 @@ public class AccessService {
 
         logService.saveAccessLog(user, AuthMethod.QR, request.getAccessType(), 0.0);
         statisticsService.updateDailyStay(user, request.getAccessType());
-        notificationService.sendPush(user, request.getAccessType() == AccessType.ENTRY ? PushType.ENTRY_SUCCESS : PushType.EXIT_SUCCESS);
+        eventPublisher.publishEvent(new AccessCompletedEvent(user, request.getAccessType()));
         return AccessResponse.builder().identifier(identifier).name(user.getName()).authMethod(AuthMethod.QR).accessType(request.getAccessType()).build();
     }
 
@@ -73,7 +72,7 @@ public class AccessService {
 
         logService.saveAccessLog(user, AuthMethod.FACE, request.getAccessType(), request.getSimilarity());
         statisticsService.updateDailyStay(user, request.getAccessType());
-        notificationService.sendPush(user, request.getAccessType() == AccessType.ENTRY ? PushType.ENTRY_SUCCESS : PushType.EXIT_SUCCESS);
+        eventPublisher.publishEvent(new AccessCompletedEvent(user, request.getAccessType()));
         return AccessResponse.builder().identifier(identifier).name(user.getName()).authMethod(AuthMethod.FACE).accessType(request.getAccessType()).similarity(request.getSimilarity()).build();
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
@@ -5,6 +5,8 @@ import com.deepnyangning.capstonebe.domain.access.dto.FaceAccessRequest;
 import com.deepnyangning.capstonebe.domain.access.dto.QrAccessRequest;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessType;
 import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
 import com.deepnyangning.capstonebe.domain.qr.service.QRService;
 import com.deepnyangning.capstonebe.domain.statistics.service.StatisticsService;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
@@ -26,6 +28,7 @@ public class AccessService {
     private final LogService logService;
     private final QRService qrService;
     private final StatisticsService statisticsService;
+    private final NotificationService notificationService;
 
     @Transactional
     public AccessResponse processQrAccess(QrAccessRequest request){
@@ -47,6 +50,7 @@ public class AccessService {
 
         logService.saveAccessLog(user, AuthMethod.QR, request.getAccessType(), 0.0);
         statisticsService.updateDailyStay(user, request.getAccessType());
+        notificationService.sendPush(user, request.getAccessType() == AccessType.ENTRY ? PushType.ENTRY_SUCCESS : PushType.EXIT_SUCCESS);
         return AccessResponse.builder().identifier(identifier).name(user.getName()).authMethod(AuthMethod.QR).accessType(request.getAccessType()).build();
     }
 
@@ -55,7 +59,7 @@ public class AccessService {
         String identifier = request.getIdentifier();
         User user = null;
 
-        if(request.getSimilarity() < 0.95){ // 임계값 추후 수정하기
+        if(request.getSimilarity() < 0.95){
             logService.saveFailLog(AuthMethod.FACE, request.getSimilarity(), ErrorCode.INSUFFICIENT_SIMILARITY);
             throw new CustomException(ErrorCode.INSUFFICIENT_SIMILARITY);
         }
@@ -69,6 +73,7 @@ public class AccessService {
 
         logService.saveAccessLog(user, AuthMethod.FACE, request.getAccessType(), request.getSimilarity());
         statisticsService.updateDailyStay(user, request.getAccessType());
+        notificationService.sendPush(user, request.getAccessType() == AccessType.ENTRY ? PushType.ENTRY_SUCCESS : PushType.EXIT_SUCCESS);
         return AccessResponse.builder().identifier(identifier).name(user.getName()).authMethod(AuthMethod.FACE).accessType(request.getAccessType()).similarity(request.getSimilarity()).build();
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportCreatedEvent.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.deepnyangning.capstonebe.domain.face.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FaceIssueReportCreatedEvent {
+    private final Long faceIssueReportId;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportEventListener.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportEventListener.java
@@ -5,6 +5,8 @@ import com.deepnyangning.capstonebe.domain.notification.service.NotificationServ
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class FaceIssueReportEventListener {
     private final NotificationService notificationService;
 
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onFaceIssueReportCreated(FaceIssueReportCreatedEvent event){
         try{
             notificationService.sendToAdmin(PushType.FACE_ISSUE_REPORTED);

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportEventListener.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/event/FaceIssueReportEventListener.java
@@ -1,0 +1,23 @@
+package com.deepnyangning.capstonebe.domain.face.event;
+
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FaceIssueReportEventListener {
+    private final NotificationService notificationService;
+
+    public void onFaceIssueReportCreated(FaceIssueReportCreatedEvent event){
+        try{
+            notificationService.sendToAdmin(PushType.FACE_ISSUE_REPORTED);
+            log.info("관리자에게 안면인식 문제 신고 알림 전송 완료: reportId = {}", event.getFaceIssueReportId());
+        } catch (Exception e){
+            log.warn("관리자 알림 전송 실패: reportId = {}", event.getFaceIssueReportId(), e);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceIssueReportService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceIssueReportService.java
@@ -2,6 +2,7 @@ package com.deepnyangning.capstonebe.domain.face.service;
 
 import com.deepnyangning.capstonebe.domain.face.dto.FaceIssueReportResponse;
 import com.deepnyangning.capstonebe.domain.face.entity.FaceIssueReport;
+import com.deepnyangning.capstonebe.domain.face.event.FaceIssueReportCreatedEvent;
 import com.deepnyangning.capstonebe.domain.face.mapper.FaceIssueReportMapper;
 import com.deepnyangning.capstonebe.domain.face.repository.FaceIssueReportRepository;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
@@ -9,6 +10,7 @@ import com.deepnyangning.capstonebe.domain.user.service.UserService;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ public class FaceIssueReportService {
     private final FaceIssueReportRepository faceIssueReportRepository;
     private final UserService userService;
     private final FaceIssueReportMapper faceIssueReportMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public FaceIssueReportResponse saveFaceIssueReport(String identifier){
@@ -31,6 +34,7 @@ public class FaceIssueReportService {
                 .build();
 
         faceIssueReportRepository.save(faceIssueReport);
+        eventPublisher.publishEvent(new FaceIssueReportCreatedEvent(faceIssueReport.getId()));
         return faceIssueReportMapper.toResponseDto(faceIssueReport);
     }
 

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/controller/NotificationController.java
@@ -1,11 +1,36 @@
 package com.deepnyangning.capstonebe.domain.notification.controller;
 
+import com.deepnyangning.capstonebe.domain.notification.dto.FcmTokenRequest;
 import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
+import com.deepnyangning.capstonebe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/notifications")
 public class NotificationController {
     private final NotificationService notificationService;
+
+    @PostMapping("/tokens")
+    public ResponseEntity<ApiResponse<Void>> saveFcmToken(@AuthenticationPrincipal UserDetails userDetails,
+                                                          @RequestBody FcmTokenRequest request){
+        String identifier = userDetails.getUsername();
+        notificationService.saveToken(identifier, request.getToken());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.<Void>builder().success(true).code(200).message("FCM 토큰 저장에 성공했습니다.").build());
+    }
+
+    @DeleteMapping("/tokens")
+    public ResponseEntity<ApiResponse<Void>> deleteFcmToken(@AuthenticationPrincipal UserDetails userDetails,
+                                                            @RequestBody FcmTokenRequest request){
+        String identifier = userDetails.getUsername();
+        notificationService.deleteToken(identifier, request.getToken());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.<Void>builder().success(true).code(200).message("FCM 토큰 삭제에 성공했습니다.").build());
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/dto/FcmTokenRequest.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/dto/FcmTokenRequest.java
@@ -1,0 +1,12 @@
+package com.deepnyangning.capstonebe.domain.notification.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FcmTokenRequest {
+    private String token;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/FcmToken.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/FcmToken.java
@@ -1,0 +1,24 @@
+package com.deepnyangning.capstonebe.domain.notification.entity;
+
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.global.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FcmToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/PushType.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/PushType.java
@@ -3,7 +3,6 @@ package com.deepnyangning.capstonebe.domain.notification.entity;
 public enum PushType {
     ENTRY_SUCCESS,
     EXIT_SUCCESS,
-    ACCESS_FAILURE,
     STUDY_ROOM_REMINDER,
     FACE_ISSUE_REPORTED
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/PushType.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/entity/PushType.java
@@ -1,0 +1,9 @@
+package com.deepnyangning.capstonebe.domain.notification.entity;
+
+public enum PushType {
+    ENTRY_SUCCESS,
+    EXIT_SUCCESS,
+    ACCESS_FAILURE,
+    STUDY_ROOM_REMINDER,
+    FACE_ISSUE_REPORTED
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,18 @@
+package com.deepnyangning.capstonebe.domain.notification.repository;
+
+import com.deepnyangning.capstonebe.domain.notification.entity.FcmToken;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    List<FcmToken> findByUser(User user);
+
+    Optional<FcmToken> findByToken(String token);
+
+    void deleteByUserAndToken(User user, String token);
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/service/NotificationService.java
@@ -1,7 +1,89 @@
 package com.deepnyangning.capstonebe.domain.notification.service;
 
+import com.deepnyangning.capstonebe.domain.notification.dto.FcmTokenRequest;
+import com.deepnyangning.capstonebe.domain.notification.entity.FcmToken;
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.notification.repository.FcmTokenRepository;
+import com.deepnyangning.capstonebe.domain.notification.util.PushMessageFactory;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.service.UserService;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class NotificationService {
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserService userService;
+    private final FirebaseMessaging firebaseMessaging;
+
+    // 사용자의 FCM 토큰을 저장
+    @Transactional
+    public void saveToken(String identifier, String token){
+        User user = userService.findByIdentifier(identifier);
+
+        // 중복 저장 방지
+        if(fcmTokenRepository.findByToken(token).isPresent()){
+            return;
+        }
+
+        FcmToken fcmToken = FcmToken.builder()
+                .user(user)
+                .token(token)
+                .build();
+        fcmTokenRepository.save(fcmToken);
+    }
+
+    // 지정된 사용자에게 PushType에 따라 푸시 알림 전송
+    public void sendPush(User user, PushType type){
+        //User user = userService.findByIdentifier(identifier);
+        List<FcmToken> tokens = fcmTokenRepository.findByUser(user);
+
+        String message = PushMessageFactory.getMessage(type);
+        String targetScreen = PushMessageFactory.getTargetScreen(type);
+
+        for(FcmToken token : tokens){
+            try{
+                Message fcmMessage = Message.builder()
+                        .setToken(token.getToken())
+                        .setNotification(Notification.builder()
+                                .setTitle("딥냥닝") // 추후 변경
+                                .setBody(message)
+                                .build()
+                        )
+                        .putData("targetScreen", targetScreen)
+                        .setAndroidConfig(AndroidConfig.builder()
+                                .setPriority(AndroidConfig.Priority.HIGH)
+                                .build())
+                        .build();
+
+                firebaseMessaging.send(fcmMessage);
+            } catch (FirebaseMessagingException e) {
+                log.warn("FCM 푸시 전송 실패 - token: {}, error: {}", token.getToken(), e.getMessage());
+                if (e.getMessage().contains("registration-token-not-registered")) {
+                    fcmTokenRepository.delete(token);
+                }
+            }
+        }
+    }
+
+    // 관리자에게 푸시 알림 전송
+    public void sendToAdmin(PushType type){
+        List<User> admins = userService.findAdmins();
+        for(User admin : admins){
+            sendPush(admin, type);
+        }
+    }
+
+    @Transactional
+    public void deleteToken(String identifier, String token){
+        User user = userService.findByIdentifier(identifier);
+        fcmTokenRepository.deleteByUserAndToken(user, token);
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/service/NotificationService.java
@@ -42,7 +42,6 @@ public class NotificationService {
 
     // 지정된 사용자에게 PushType에 따라 푸시 알림 전송
     public void sendPush(User user, PushType type){
-        //User user = userService.findByIdentifier(identifier);
         List<FcmToken> tokens = fcmTokenRepository.findByUser(user);
 
         String message = PushMessageFactory.getMessage(type);

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/util/PushMessageFactory.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/util/PushMessageFactory.java
@@ -7,7 +7,6 @@ public class PushMessageFactory {
         return switch (type){
             case ENTRY_SUCCESS ->  "입장 완료! 오늘도 힘찬 하루 보내세요.";
             case EXIT_SUCCESS -> "퇴장이 완료되었습니다. 오늘도 고생하셨어요!";
-            case ACCESS_FAILURE -> "출입에 실패했습니다. 다시 시도해 주세요.";
             case STUDY_ROOM_REMINDER -> "예약하신 스터디룸 이용까지 30분 남았어요!";
             case FACE_ISSUE_REPORTED -> "안면 인식 오류가 접수되었습니다. 조치가 필요합니다.";
         };
@@ -15,9 +14,9 @@ public class PushMessageFactory {
 
     public static String getTargetScreen(PushType type){
         return switch (type) {
-            case ENTRY_SUCCESS, EXIT_SUCCESS, ACCESS_FAILURE -> "home";
+            case ENTRY_SUCCESS, EXIT_SUCCESS -> "home";
             case STUDY_ROOM_REMINDER -> "studyroom/reservations";
             case FACE_ISSUE_REPORTED -> "admin/reports";
         };
-    } // 프론트랑 다시 얘기하기
+    } // 프론트랑 얘기해서 보완
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/notification/util/PushMessageFactory.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/notification/util/PushMessageFactory.java
@@ -1,0 +1,23 @@
+package com.deepnyangning.capstonebe.domain.notification.util;
+
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+
+public class PushMessageFactory {
+    public static String getMessage(PushType type){
+        return switch (type){
+            case ENTRY_SUCCESS ->  "입장 완료! 오늘도 힘찬 하루 보내세요.";
+            case EXIT_SUCCESS -> "퇴장이 완료되었습니다. 오늘도 고생하셨어요!";
+            case ACCESS_FAILURE -> "출입에 실패했습니다. 다시 시도해 주세요.";
+            case STUDY_ROOM_REMINDER -> "예약하신 스터디룸 이용까지 30분 남았어요!";
+            case FACE_ISSUE_REPORTED -> "안면 인식 오류가 접수되었습니다. 조치가 필요합니다.";
+        };
+    }
+
+    public static String getTargetScreen(PushType type){
+        return switch (type) {
+            case ENTRY_SUCCESS, EXIT_SUCCESS, ACCESS_FAILURE -> "home";
+            case STUDY_ROOM_REMINDER -> "studyroom/reservations";
+            case FACE_ISSUE_REPORTED -> "admin/reports";
+        };
+    } // 프론트랑 다시 얘기하기
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/repository/StudyRoomReservationRepository.java
@@ -57,4 +57,6 @@ public interface StudyRoomReservationRepository extends JpaRepository<StudyRoomR
                                                         @Param("startTime") LocalTime startTime,
                                                         @Param("endTime") LocalTime endTime,
                                                         @Param("status") ReservationStatus status);
+
+    List<StudyRoomReservation> findByDateAndStartTimeAndStatus(LocalDate date, LocalTime startTime, ReservationStatus status);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/ReservationPushScheduler.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/ReservationPushScheduler.java
@@ -8,6 +8,7 @@ import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReserva
 import com.deepnyangning.capstonebe.domain.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationPushScheduler {
@@ -41,9 +43,22 @@ public class ReservationPushScheduler {
 
         List<StudyRoomReservation> reservations = reservationRepository.findByDateAndStartTimeAndStatus(date, startTime, ReservationStatus.CONFIRMED);
 
+        int successCnt = 0;
+        int failCnt = 0;
+
         for(StudyRoomReservation reservation : reservations){
             User user = reservation.getUser();
-            notificationService.sendPush(user, PushType.STUDY_ROOM_REMINDER);
+            try{
+                notificationService.sendPush(user, PushType.STUDY_ROOM_REMINDER);
+                successCnt++;
+                log.debug("스터디룸 리마인드 푸시 전송 성공: ientifier={}, reservationId={}", user.getIdentifier(), reservation.getId());
+            } catch (Exception e){
+                failCnt++;
+                log.debug("스터디룸 리마인드 푸시 전송 실패: identifier={}, reservationId={}, error={}", user.getIdentifier(), reservation.getId(), e.toString());
+            }
         }
+
+        log.info("스터디룸 리마인드 알림 전송 완료 - 날짜: {}, 시작 시간: {}, 총 대상: {}건, 성공: {}건, 실패: {}건",
+                date, startTime, reservations.size(), successCnt, failCnt);
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/ReservationPushScheduler.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/ReservationPushScheduler.java
@@ -1,0 +1,49 @@
+package com.deepnyangning.capstonebe.domain.studyroom.service;
+
+import com.deepnyangning.capstonebe.domain.notification.entity.PushType;
+import com.deepnyangning.capstonebe.domain.notification.service.NotificationService;
+import com.deepnyangning.capstonebe.domain.studyroom.entity.ReservationStatus;
+import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
+import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReservationRepository;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationPushScheduler {
+    private final StudyRoomReservationRepository reservationRepository;
+    private final NotificationService notificationService;
+
+    // 월~금 9:30~20:30 1시간 마다 실행
+    @Scheduled(cron = "0 30 9-20 * * MON-FRI")
+    @Transactional(readOnly = true)
+    public void sendPushMessageWeekday(){
+        sendPushMessage(LocalTime.now().plusMinutes(30));
+    }
+
+    // 토요일 9:30~15:30 1시간 마다 실행
+    @Scheduled(cron = "0 30 9-15 * * SAT")
+    @Transactional(readOnly = true)
+    public void sendPushMessageSaturday(){
+        sendPushMessage(LocalTime.now().plusMinutes(30));
+    }
+
+    private void sendPushMessage(LocalTime startTime){
+        LocalDate date = LocalDate.now();
+
+        List<StudyRoomReservation> reservations = reservationRepository.findByDateAndStartTimeAndStatus(date, startTime, ReservationStatus.CONFIRMED);
+
+        for(StudyRoomReservation reservation : reservations){
+            User user = reservation.getUser();
+            notificationService.sendPush(user, PushType.STUDY_ROOM_REMINDER);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.deepnyangning.capstonebe.domain.user.repository;
 
+import com.deepnyangning.capstonebe.domain.user.entity.Role;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByIdentifier(String identifier);
 
     boolean existsByIdentifierAndName(String identifier, String name);
+
+    List<User> findByRole(Role role);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/service/UserService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.deepnyangning.capstonebe.domain.user.service;
 
 import com.deepnyangning.capstonebe.domain.user.dto.PasswordUpdate;
+import com.deepnyangning.capstonebe.domain.user.entity.Role;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
 import com.deepnyangning.capstonebe.domain.user.repository.UserRepository;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +24,8 @@ public class UserService {
                 .orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
-    public User findById(Long id){
-        return userRepository.findById(id)
-                .orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+    public List<User> findAdmins(){
+        return userRepository.findByRole(Role.ADMIN);
     }
 
     public boolean existsByIdentifier(String identifier){

--- a/src/main/java/com/deepnyangning/capstonebe/global/config/FirebaseConfig.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/config/FirebaseConfig.java
@@ -5,9 +5,10 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
 import java.io.IOException;
@@ -16,11 +17,12 @@ import java.io.InputStream;
 @Configuration
 @Slf4j
 public class FirebaseConfig {
+    @Value("${firebase.key-path}")
+    private String keyPath;
 
     @Bean
     public FirebaseMessaging firebaseMessaging() throws IOException {
-
-        Resource resource = new ClassPathResource("firebase/serviceAccountKey.json");
+        Resource resource = new FileSystemResource(keyPath);
         InputStream serviceAccount = resource.getInputStream();
 
         FirebaseOptions options = FirebaseOptions.builder()
@@ -29,6 +31,7 @@ public class FirebaseConfig {
 
         if(FirebaseApp.getApps().isEmpty()){
             FirebaseApp.initializeApp(options);
+            log.info("FirebaseApp이 초기화되었습니다. 경로: {}", keyPath);
         }
 
         return FirebaseMessaging.getInstance();

--- a/src/main/java/com/deepnyangning/capstonebe/global/config/FirebaseConfig.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/config/FirebaseConfig.java
@@ -1,0 +1,36 @@
+package com.deepnyangning.capstonebe.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+
+        Resource resource = new ClassPathResource("firebase/serviceAccountKey.json");
+        InputStream serviceAccount = resource.getInputStream();
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        if(FirebaseApp.getApps().isEmpty()){
+            FirebaseApp.initializeApp(options);
+        }
+
+        return FirebaseMessaging.getInstance();
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

FCM 기반 푸시 알림 기능 구현

## ➕ 추가/변경된 기능

- FCM 토큰 관리 API
- 푸시 알림 전송 기능
- 푸시 알림 유형 및 전송 메시지, 이동할 페이지 정의
- 각 로직 트랜잭션 커밋 후 푸시 알림 전송 처리 (이벤트 리스너 활용) - 스터디룸 예약 30분 전 리마인드 / 출입 성공 알림 / 안면인식 문제 신고 접수 알림
- 로깅
- ci cd 코드 수정

## 🗎 관련 이슈

< #39 >