### PR TITLE
Feat/43 사용자 얼굴 등록 여부 반환

### DIFF
--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
@@ -36,5 +36,8 @@ public class FaceDataService {
         if("FAIL".equals(aiServerResponse)){
             throw new CustomException(ErrorCode.FACE_REGISTRATION_FAILED);
         }
+        else{
+            user.setFaceRegistered(true);
+        }
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/dto/UserResponse.java
@@ -12,4 +12,6 @@ public class UserResponse {
     private String identifier;
 
     private String name;
+
+    private boolean faceRegistered;
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/entity/User.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/entity/User.java
@@ -27,4 +27,8 @@ public class User extends BaseEntity {
 
     @Builder.Default
     private boolean isActive = true;
+
+    @Builder.Default
+    private boolean isFaceRegistered = false;
+
 }

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
@@ -1,40 +1,71 @@
 package com.deepnyangning.capstonebe.external.ai;
 
+import com.deepnyangning.capstonebe.external.ai.dto.AiResponse;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.util.List;
+
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class AiServerClient {
-    private static final String AI_SERVER_URL = "https://1ac8-116-44-51-91.ngrok-free.app/register_face";
+    private static final String AI_SERVER_URL = "https://927a-116-44-51-91.ngrok-free.app/register_face";
+    private final RestTemplate restTemplate;
+
 
     public String sendFaceDataToAiServer(MultipartFile file, String identifier){
         try {
+            if (file == null || file.isEmpty()) {
+                log.error("파일이 없거나 비어 있음");
+                throw new CustomException(ErrorCode.INVALID_VIDEO_FILE);
+            }
+
+            log.info("파일 전송: URL={}, 이름={}, 크기={}, identifier={}", AI_SERVER_URL, file.getOriginalFilename(), file.getSize(), identifier);
+
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", new ByteArrayResource(file.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return file.getOriginalFilename(); // null 방지
-                }
-            });
+            File tempFile = File.createTempFile("upload", file.getOriginalFilename());
+            file.transferTo(tempFile);
+            body.add("file", new FileSystemResource(tempFile));
             body.add("identifier", identifier);
 
             HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
 
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> response = restTemplate.exchange(AI_SERVER_URL, HttpMethod.POST, request, String.class);
+            ResponseEntity<AiResponse> response = restTemplate.exchange(AI_SERVER_URL, HttpMethod.POST, request, AiResponse.class);
 
-            return response.getStatusCode().is2xxSuccessful() ? "SUCCESS" : "FAIL";
-        } catch (Exception e){
+            tempFile.delete();
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null && response.getBody().isSuccess()) {
+                return "SUCCESS";
+            } else {
+                log.warn("AI 서버 응답 실패: 상태={}, 본문={}", response.getStatusCode(), response.getBody());
+                return "FAIL";
+            }
+        } catch (HttpClientErrorException.NotFound e) {
+            log.error("AI 서버 엔드포인트 없음 (404): URL={}", AI_SERVER_URL, e);
+            throw new CustomException(ErrorCode.AI_SERVER_ENDPOINT_NOT_FOUND);
+        } catch (ResourceAccessException e) {
+            log.error("AI 서버 연결 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.AI_SERVER_UNREACHABLE);
+        } catch (Exception e) {
+            log.error("AI 서버 호출 실패: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.AI_SERVER_COMMUNICATION_FAILED);
         }
     }

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class AiServerClient {
-    private static final String AI_SERVER_URL = ""; // 추후 작성
+    private static final String AI_SERVER_URL = "https://1ac8-116-44-51-91.ngrok-free.app/register_face";
 
     public String sendFaceDataToAiServer(MultipartFile file, String identifier){
         try {

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/dto/AiResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/dto/AiResponse.java
@@ -1,0 +1,8 @@
+package com.deepnyangning.capstonebe.external.ai.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AiResponse {
+    private boolean success;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/code/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     FACE_ISSUE_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "안면 인식 문제 신고 데이터를 찾을 수 없습니다."),
     ACCESS_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "출입 로그를 찾을 수 없습니다."),
     GLOBAL_AVG_NOT_FOUND(HttpStatus.NOT_FOUND, "전체 사용자의 출입 통계 기록을 찾을 수 없습니다."),
+    AI_SERVER_ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, "AI 서버 엔드포인트를 찾을 수 없습니다."),
 
     /*
      * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출
@@ -67,7 +68,8 @@ public enum ErrorCode {
      * 503 SERVICE_UNAVAILABLE: 서비스 이용 불가
      */
     REDIS_OPERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Redis 작업에 실패했습니다."),
-    AI_SERVER_COMMUNICATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서버와의 통신에 실패했습니다.");
+    AI_SERVER_COMMUNICATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서버와의 통신에 실패했습니다."),
+    AI_SERVER_UNREACHABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 서버에 연결할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/deepnyangning/capstonebe/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.deepnyangning.capstonebe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

프론트 요청에 따라 GET /users API 응답에 얼굴 등록 여부(isFaceRegistered) 포함
얼굴 등록 관련 AI 서버와의 연동 완료

## ➕ 추가/변경된 기능

- UserResponse DTO에 isFaceRegistered 필드 추가
- 얼굴 등록 여부 판단 로직 추가
- API 응답 값에 반영
- 얼굴 등록 ai 서버와의 연동 테스트

## 🗎 관련 이슈

< #43 >