### PR TITLE
Refactor/45 사용자 인증 방식 통일 및 응답값 개선

### DIFF
--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/controller/LogController.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.access.controller;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogPreviewResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.FailLogResponse;
 import com.deepnyangning.capstonebe.domain.access.entity.AuthMethod;
@@ -23,17 +24,17 @@ public class LogController {
     private final LogService logService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<AccessLogResponse>>> getAccessLogs(@RequestParam(required = false) LocalDateTime startTime,
-                                                                              @RequestParam(required = false) LocalDateTime endTime,
-                                                                              @RequestParam(required = false) String identifier,
-                                                                              @RequestParam(required = false) String name,
-                                                                              @RequestParam(required = false) AuthMethod authMethod,
-                                                                              @RequestParam(defaultValue = "0") int page,
-                                                                              @RequestParam(defaultValue = "7") int size){
+    public ResponseEntity<ApiResponse<Page<AccessLogPreviewResponse>>> getAccessLogs(@RequestParam(required = false) LocalDateTime startTime,
+                                                                                     @RequestParam(required = false) LocalDateTime endTime,
+                                                                                     @RequestParam(required = false) String identifier,
+                                                                                     @RequestParam(required = false) String name,
+                                                                                     @RequestParam(required = false) AuthMethod authMethod,
+                                                                                     @RequestParam(defaultValue = "0") int page,
+                                                                                     @RequestParam(defaultValue = "7") int size){
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "accessTime"));
-        Page<AccessLogResponse> response = logService.findAccessLogs(startTime, endTime, identifier, name, authMethod, pageable);
+        Page<AccessLogPreviewResponse> response = logService.findAccessLogs(startTime, endTime, identifier, name, authMethod, pageable);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<Page<AccessLogResponse>>builder().result(response).success(true).code(200).message("출입 로그 목록을 성공적으로 조회했습니다.").build());
+                .body(ApiResponse.<Page<AccessLogPreviewResponse>>builder().result(response).success(true).code(200).message("출입 로그 목록을 성공적으로 조회했습니다.").build());
     }
 
     @GetMapping("/{logId}")

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogPreviewResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/dto/AccessLogPreviewResponse.java
@@ -12,10 +12,10 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AccessLogResponse {
+public class AccessLogPreviewResponse {
     private Long id;
 
-    private AccessLogUserInfo userInfo;
+    private String identifier;
 
     private AccessType accessType;
 
@@ -23,6 +23,4 @@ public class AccessLogResponse {
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime accessTime;
-
-    private double similarity;
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
@@ -3,12 +3,13 @@ package com.deepnyangning.capstonebe.domain.access.mapper;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogPreviewResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
+import com.deepnyangning.capstonebe.domain.user.mapper.UserMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {UserMapper.class})
 public interface AccessLogMapper {
-    @Mapping(target = "userInfo", ignore = true)
+    @Mapping(source = "user", target = "userInfo")
     AccessLogResponse toResponseDto(AccessLog accessLog);
 
     @Mapping(source = "user.identifier", target = "identifier")

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/mapper/AccessLogMapper.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.access.mapper;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogPreviewResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
 import org.mapstruct.Mapper;
@@ -9,4 +10,7 @@ import org.mapstruct.Mapping;
 public interface AccessLogMapper {
     @Mapping(target = "userInfo", ignore = true)
     AccessLogResponse toResponseDto(AccessLog accessLog);
+
+    @Mapping(source = "user.identifier", target = "identifier")
+    AccessLogPreviewResponse toPreviewDto(AccessLog accessLog);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/AccessService.java
@@ -26,7 +26,6 @@ public class AccessService {
     private final LogService logService;
     private final QRService qrService;
     private final StatisticsService statisticsService;
-    private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
@@ -34,7 +34,6 @@ import java.time.LocalDateTime;
 public class LogService {
     private final AccessLogRepository accessLogRepository;
     private final FailLogRepository failLogRepository;
-    private final UserMapper userMapper;
     private final AccessLogMapper accessLogMapper;
     private final FailLogMapper failLogMapper;
 
@@ -73,19 +72,13 @@ public class LogService {
     }
 
     public AccessLogResponse findAccessLog(Long logId){
-        return toAccessLogResponse(accessLogRepository.findById(logId)
+        return accessLogMapper.toResponseDto(accessLogRepository.findById(logId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ACCESS_LOG_NOT_FOUND)));
     }
 
     public Page<FailLogResponse> findFailLogs(LocalDateTime startTime, LocalDateTime endTime, AuthMethod authMethod, Pageable pageable){
         Specification<FailLog> spec = FailLogSpecification.withFilters(startTime, endTime, authMethod);
         return failLogRepository.findAll(spec, pageable).map(failLogMapper::toResponseDto);
-    }
-
-    private AccessLogResponse toAccessLogResponse(AccessLog accessLog){
-        AccessLogResponse dto = accessLogMapper.toResponseDto(accessLog);
-        dto.setUserInfo(userMapper.toAccessLogUserInfo(accessLog.getUser()));
-        return dto;
     }
 
     public LocalDateTime findLatestEntryTime(User user){

--- a/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/access/service/LogService.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.access.service;
 
+import com.deepnyangning.capstonebe.domain.access.dto.AccessLogPreviewResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogResponse;
 import com.deepnyangning.capstonebe.domain.access.dto.FailLogResponse;
 import com.deepnyangning.capstonebe.domain.access.entity.AccessLog;
@@ -65,10 +66,10 @@ public class LogService {
         log.warn(message);
     }
 
-    public Page<AccessLogResponse> findAccessLogs(LocalDateTime startTime, LocalDateTime endTime,
-                                                  String identifier, String name, AuthMethod authMethod, Pageable pageable){
+    public Page<AccessLogPreviewResponse> findAccessLogs(LocalDateTime startTime, LocalDateTime endTime,
+                                                         String identifier, String name, AuthMethod authMethod, Pageable pageable){
         Specification<AccessLog> spec = AccessLogSpecification.withFilters(startTime, endTime, identifier, name, authMethod);
-        return accessLogRepository.findAll(spec, pageable).map(this::toAccessLogResponse);
+        return accessLogRepository.findAll(spec, pageable).map(accessLogMapper::toPreviewDto);
     }
 
     public AccessLogResponse findAccessLog(Long logId){

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/dto/FaceIssueReportResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/dto/FaceIssueReportResponse.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.face.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,7 +17,9 @@ public class FaceIssueReportResponse {
 
     private boolean read;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/qr/controller/QRController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/qr/controller/QRController.java
@@ -5,6 +5,8 @@ import com.deepnyangning.capstonebe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,7 +19,8 @@ public class QRController {
     private final QRService qrService;
 
     @PostMapping("/generate")
-    public ResponseEntity<ApiResponse<String>> generateQr(@RequestParam String identifier){
+    public ResponseEntity<ApiResponse<String>> generateQr(@AuthenticationPrincipal UserDetails userDetails){
+        String identifier = userDetails.getUsername();
         String qrCode = qrService.generateQr(identifier);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.<String>builder().result(qrCode).success(true).code(201).message("QR 코드가 성공적으로 생성되었습니다.").build());

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomController.java
@@ -1,6 +1,7 @@
 package com.deepnyangning.capstonebe.domain.studyroom.controller;
 
 import com.deepnyangning.capstonebe.domain.studyroom.dto.StudyRoomResponse;
+import com.deepnyangning.capstonebe.domain.studyroom.dto.StudyRoomSimpleResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.mapper.StudyRoomMapper;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomService;
 import com.deepnyangning.capstonebe.global.response.ApiResponse;
@@ -28,10 +29,10 @@ public class StudyRoomController {
     private final StudyRoomMapper studyRoomMapper;
 
     @GetMapping("/studyrooms/{id}")
-    public ResponseEntity<ApiResponse<StudyRoomResponse>> getStudyRoom(@PathVariable Long id){
-        StudyRoomResponse studyRoomResponse = studyRoomMapper.toResponseDto(studyRoomService.findStudyRoomById(id));
+    public ResponseEntity<ApiResponse<StudyRoomSimpleResponse>> getStudyRoom(@PathVariable Long id){
+        StudyRoomSimpleResponse studyRoomResponse = studyRoomMapper.toSimpleDto(studyRoomService.findStudyRoomById(id));
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<StudyRoomResponse>builder().result(studyRoomResponse).success(true).code(200).message("스터디룸 상세 조회에 성공했습니다.").build());
+                .body(ApiResponse.<StudyRoomSimpleResponse>builder().result(studyRoomResponse).success(true).code(200).message("스터디룸 상세 조회에 성공했습니다.").build());
     }
 
     @GetMapping("/studyrooms")

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/controller/StudyRoomReservationController.java
@@ -1,9 +1,6 @@
 package com.deepnyangning.capstonebe.domain.studyroom.controller;
 
-import com.deepnyangning.capstonebe.domain.studyroom.dto.ParticipantRequest;
-import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationRequest;
-import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationResponse;
-import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUpdate;
+import com.deepnyangning.capstonebe.domain.studyroom.dto.*;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomParticipantService;
 import com.deepnyangning.capstonebe.domain.studyroom.service.StudyRoomReservationService;
 import com.deepnyangning.capstonebe.global.response.ApiResponse;
@@ -40,7 +37,6 @@ public class StudyRoomReservationController {
         String message = exists ? "존재하는 사용자입니다." : "일치하는 사용자가 존재하지 않습니다.";
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.<Boolean>builder().result(exists).success(true).code(200).message(message).build());
     }
-    // participantResponse로 응답하는 거 고려하기
 
     @PostMapping("/studyrooms/reservations")
     public ResponseEntity<ApiResponse<ReservationResponse>> createStudyRoomReservation(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ReservationRequest reservationRequest){
@@ -50,11 +46,12 @@ public class StudyRoomReservationController {
                 .body(ApiResponse.<ReservationResponse>builder().result(reservationResponse).success(true).code(201).message("스터디룸 예약에 성공했습니다.").build());
     }
 
-    @GetMapping("/studyrooms/reservations/users/{userId}")
-    public ResponseEntity<ApiResponse<CursorPage<ReservationResponse>>> getStudyRoomReservationsByUser(@PathVariable Long userId,
+    @GetMapping("/studyrooms/reservations/my")
+    public ResponseEntity<ApiResponse<CursorPage<ReservationResponse>>> getStudyRoomReservationsByUser(@AuthenticationPrincipal UserDetails userDetails,
                                                                                                        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
                                                                                                        @RequestParam(defaultValue = "7") int size){
-        List<ReservationResponse> response = reservationService.findReservationsByUser(userId, cursorDate, size);
+        String identifier = userDetails.getUsername();
+        List<ReservationResponse> response = reservationService.findReservationsByUser(identifier, cursorDate, size);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.<CursorPage<ReservationResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("사용자별 스터디룸 예약 조회에 성공했습니다.").build());
     }
@@ -81,19 +78,19 @@ public class StudyRoomReservationController {
     }
 
     @GetMapping("/admin/studyrooms/reservations")
-    public ResponseEntity<ApiResponse<CursorPage<ReservationResponse>>> getStudyRoomReservations(@RequestParam(required = false) String name,
-                                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
-                                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "HH:mm") LocalTime cursorStartTime,
-                                                                                                 @RequestParam(defaultValue = "7") int size){
-        List<ReservationResponse> response = reservationService.findReservationsByStudyRoomName(name, cursorDate, cursorStartTime, size);
+    public ResponseEntity<ApiResponse<CursorPage<AdminReservationResponse>>> getStudyRoomReservations(@RequestParam(required = false) String name,
+                                                                                                      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate cursorDate,
+                                                                                                      @RequestParam(required = false) @DateTimeFormat(pattern = "HH:mm") LocalTime cursorStartTime,
+                                                                                                      @RequestParam(defaultValue = "7") int size){
+        List<AdminReservationResponse> response = reservationService.findReservationsByStudyRoomName(name, cursorDate, cursorStartTime, size);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<CursorPage<ReservationResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("스터디룸 예약 전체 조회에 성공했습니다.").build());
+                .body(ApiResponse.<CursorPage<AdminReservationResponse>>builder().result(CursorPage.of(response, size)).success(true).code(200).message("스터디룸 예약 전체 조회에 성공했습니다.").build());
     }
 
     @PutMapping("/admin/studyrooms/reservations/{reservationId}")
-    public ResponseEntity<ApiResponse<ReservationResponse>> updateStudyRoomReservationStatus(@PathVariable Long reservationId, @RequestParam String status){
-        ReservationResponse reservationResponse = reservationService.updateReservationStatus(reservationId, status);
+    public ResponseEntity<ApiResponse<AdminReservationResponse>> updateStudyRoomReservationStatus(@PathVariable Long reservationId, @RequestParam String status){
+        AdminReservationResponse reservationResponse = reservationService.updateReservationStatus(reservationId, status);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.<ReservationResponse>builder().result(reservationResponse).success(true).code(200).message("스터디룸 예약 상태 변경에 성공했습니다.").build());
+                .body(ApiResponse.<AdminReservationResponse>builder().result(reservationResponse).success(true).code(200).message("스터디룸 예약 상태 변경에 성공했습니다.").build());
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/AdminReservationResponse.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/AdminReservationResponse.java
@@ -12,8 +12,10 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ReservationResponse {
+public class AdminReservationResponse {
     private Long id;
+
+    private ReservationUserInfo userInfo;
 
     private StudyRoomSimpleResponse studyRoom;
 

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ReservationRequest.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ReservationRequest.java
@@ -20,8 +20,6 @@ import java.util.List;
 public class ReservationRequest {
     private Long studyRoomId;
 
-    private Long userId;
-
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ReservationUserInfo.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/dto/ReservationUserInfo.java
@@ -1,0 +1,14 @@
+package com.deepnyangning.capstonebe.domain.studyroom.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReservationUserInfo {
+    private String identifier;
+
+    private String name;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/mapper/StudyRoomMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/mapper/StudyRoomMapper.java
@@ -1,10 +1,12 @@
 package com.deepnyangning.capstonebe.domain.studyroom.mapper;
 
 import com.deepnyangning.capstonebe.domain.studyroom.dto.StudyRoomResponse;
+import com.deepnyangning.capstonebe.domain.studyroom.dto.StudyRoomSimpleResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoom;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface StudyRoomMapper {
     StudyRoomResponse toResponseDto(StudyRoom studyRoom);
+    StudyRoomSimpleResponse toSimpleDto(StudyRoom studyRoom);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/mapper/StudyRoomReservationMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/mapper/StudyRoomReservationMapper.java
@@ -1,14 +1,16 @@
 package com.deepnyangning.capstonebe.domain.studyroom.mapper;
 
+import com.deepnyangning.capstonebe.domain.studyroom.dto.AdminReservationResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationRequest;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUpdate;
 import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation;
+import com.deepnyangning.capstonebe.domain.user.mapper.UserMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
-@Mapper(componentModel = "spring", uses = {StudyRoomMapper.class, StudyRoomParticipantMapper.class})
+@Mapper(componentModel = "spring", uses = {StudyRoomMapper.class, StudyRoomParticipantMapper.class, UserMapper.class})
 public interface StudyRoomReservationMapper {
     @Mapping(target = "studyRoom", ignore = true)
     @Mapping(target = "user", ignore = true)
@@ -16,7 +18,6 @@ public interface StudyRoomReservationMapper {
     StudyRoomReservation toEntity(ReservationRequest reservationRequest);
 
     @Mapping(source = "studyRoom", target = "studyRoom")
-    @Mapping(source = "user.id", target = "userId")
     @Mapping(source = "participants", target = "participants")
     ReservationResponse toResponseDto(StudyRoomReservation studyRoomReservation);
 
@@ -25,4 +26,9 @@ public interface StudyRoomReservationMapper {
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "participants", ignore = true)
     void update(@MappingTarget StudyRoomReservation reservation, ReservationUpdate update);
+
+    @Mapping(source = "studyRoom", target = "studyRoom")
+    @Mapping(source = "participants", target = "participants")
+    @Mapping(source = "user", target = "userInfo")
+    AdminReservationResponse toAdminResponse(StudyRoomReservation studyRoomReservation);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/studyroom/service/StudyRoomReservationService.java
@@ -1,5 +1,6 @@
 package com.deepnyangning.capstonebe.domain.studyroom.service;
 
+import com.deepnyangning.capstonebe.domain.studyroom.dto.AdminReservationResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationRequest;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationResponse;
 import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUpdate;
@@ -8,6 +9,7 @@ import com.deepnyangning.capstonebe.domain.studyroom.entity.StudyRoomReservation
 import com.deepnyangning.capstonebe.domain.studyroom.mapper.StudyRoomReservationMapper;
 import com.deepnyangning.capstonebe.domain.studyroom.repository.StudyRoomReservationRepository;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.service.UserService;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class StudyRoomReservationService {
     private final StudyRoomService studyRoomService;
     private final StudyRoomParticipantService participantService;
     private final StudyRoomReservationValidator validator;
+    private final UserService userService;
 
     @Transactional
     public ReservationResponse saveReservation(String identifier, ReservationRequest reservationRequest){
@@ -47,13 +50,14 @@ public class StudyRoomReservationService {
         return reservationMapper.toResponseDto(reservation);
     }
 
-    public List<ReservationResponse> findReservationsByStudyRoomName(String name, LocalDate cursorDate, LocalTime cursorStartTime, int size) {
+    public List<AdminReservationResponse> findReservationsByStudyRoomName(String name, LocalDate cursorDate, LocalTime cursorStartTime, int size) {
         String formattedName = (name == null || name.isBlank()) ? null : name.toUpperCase().replace(" ", "");
         List<StudyRoomReservation> reservations = reservationRepository.findByStudyRoomName(formattedName, cursorDate, cursorStartTime, size+1);
-        return reservations.stream().map(reservationMapper::toResponseDto).toList();
+        return reservations.stream().map(reservationMapper::toAdminResponse).toList();
     }
 
-    public List<ReservationResponse> findReservationsByUser(Long userId, LocalDate cursorDate, int size){
+    public List<ReservationResponse> findReservationsByUser(String identifier, LocalDate cursorDate, int size){
+        Long userId = userService.findByIdentifier(identifier).getId();
         return reservationRepository.findByUser(userId, cursorDate, size+1)
                 .stream().map(reservationMapper::toResponseDto).toList();
     }
@@ -74,11 +78,11 @@ public class StudyRoomReservationService {
     }
 
     @Transactional
-    public ReservationResponse updateReservationStatus(Long id, String status){
+    public AdminReservationResponse updateReservationStatus(Long id, String status){
         StudyRoomReservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
         reservation.setStatus(ReservationStatus.valueOf(status));
-        return reservationMapper.toResponseDto(reservation);
+        return reservationMapper.toAdminResponse(reservation);
     }
 
     @Transactional

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.deepnyangning.capstonebe.domain.user.mapper;
 
 import com.deepnyangning.capstonebe.domain.access.dto.AccessLogUserInfo;
+import com.deepnyangning.capstonebe.domain.studyroom.dto.ReservationUserInfo;
 import com.deepnyangning.capstonebe.domain.user.dto.UserResponse;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
 import org.mapstruct.Mapper;
@@ -10,4 +11,6 @@ public interface UserMapper {
     UserResponse toResponseDto(User user);
 
     AccessLogUserInfo toAccessLogUserInfo(User user);
+
+    ReservationUserInfo toReservationUserInfo(User user);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/service/AuthService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/service/AuthService.java
@@ -9,6 +9,7 @@ import com.deepnyangning.capstonebe.domain.user.entity.User;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import com.deepnyangning.capstonebe.global.util.JWTUtil;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;

--- a/src/main/java/com/deepnyangning/capstonebe/global/filter/JWTFilter.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/filter/JWTFilter.java
@@ -72,6 +72,12 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
+        if (uri.equals("/auth/reissue")) {
+            request.setAttribute("refreshToken", token);
+        } else {
+            request.setAttribute("accessToken", token);
+        }
+
         // 사용자 정보 추출
         String identifier = jwtUtil.getSubject(token);
         UserDetails userDetails = userDetailsService.loadUserByUsername(identifier);


### PR DESCRIPTION
## ❓ 기능 추가 배경

일부 api의 userId를 제거하고 모두 토큰 추출 방식으로 통일
api 응답값 개선

## ➕ 추가/변경된 기능

- qr 생성 api - identifier 파라미터 제거
- 스터디룸 예약 - dto에서 userId 제거, user별 조회 api 경로의 userId 제거, 관리자용 응답 dto 따로 설계
- 스터디룸 - 상세 조회에서 예약 정보 제거
- json 시간 포맷 변경
- 출입 로그 userInfo 매핑 로직 mapper에서 한 번에 처리하도록 리팩토링

## 🗎 관련 이슈

< #45 >