### PR TITLE
Feat/51 회원 탈퇴 AI 연동

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Generate application.yml
         run: |
           echo "${{ secrets.APPLICATION_YML_CONTENT }}" > application.yml
+          echo "" >> application.yml
+          echo "ai:" >> application.yml
+          echo "  server-url: ${{ secrets.AI_SERVER_URL }}" >> application.yml
           ls -la application.yml
 
       # 9. JAR 전송

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
             firebase:
               project-id: capstone-dnn-bfa9f
               key-path: ./src/main/resources/firebase/serviceAccountKey.json
+          
+            ai:
+              server-url: ${{ secrets.AI_SERVER_URL }}"
             EOF
 
       - name: Decode Firebase service account key

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/repository/FaceDataRepository.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/repository/FaceDataRepository.java
@@ -1,9 +1,11 @@
 package com.deepnyangning.capstonebe.domain.face.repository;
 
 import com.deepnyangning.capstonebe.domain.face.entity.FaceData;
+import com.deepnyangning.capstonebe.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FaceDataRepository extends JpaRepository<FaceData, Long> {
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/face/service/FaceDataService.java
@@ -40,4 +40,9 @@ public class FaceDataService {
             user.setFaceRegistered(true);
         }
     }
+
+    @Transactional
+    public void deleteFaceByUser(User user){
+        faceDataRepository.deleteAllByUser(user);
+    }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/statistics/controller/CongestionControllerDocs.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/statistics/controller/CongestionControllerDocs.java
@@ -12,7 +12,7 @@ public interface CongestionControllerDocs {
                     **도서관 혼잡도 조회**
                                     
                     조회 요청 시간 기준의 혼잡도 데이터를 조회합니다. \s
-                    현재 도서관 이용자 수와 최근 일주일 간의 평균 이용자 수 정보가 제공됩니다.
+                    현재 도서관 이용자 수와 최근 일주일 간의 평균 이용자 수 정보와 함께 메시지가 제공됩니다.
                                                        
                     **요청 헤더**
                                     
@@ -29,6 +29,7 @@ public interface CongestionControllerDocs {
                         - `result`: 혼잡도 데이터
                           - `currentUsers`: 현재 이용자 수 (예: 503)
                           - `avgUsers`: 평균 이용자 수 (예: 452)
+                          - `message`: 혼잡도 메시지 (예: "평균보다 +11% 많음 (약간 혼잡)")
                     """
     )
     public ResponseEntity<ApiResponse<CongestionResponse>> getCongestionData();

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/controller/UserControllerDocs.java
@@ -85,17 +85,15 @@ public interface UserControllerDocs {
                     **처리 흐름**
                     - 로그인된 사용자 식별
                     - 해당 사용자 엔티티의 active 값을 false로 설정
+                    - DB의 사용자 FaceData 삭제
+                    - ai 서버에 얼굴 데이터 삭제 요청 (비동기로 처리되어 AI 서버의 응답을 기다리지 않고 탈퇴 응답)
                                         
                     **예외 사항**
                     - 사용자가 존재하지 않는 경우 예외 발생
                                         
                     **요청 헤더**
                                     
-                    - `Authorization: Bearer {accessToken}` : 사용자 인증을 위해 accessToken을 헤더에 포함해야 합니다.
-                                        
-                    **요청 필드**
-                    - `currentPassword` : 현재 비밀번호 (예: "oldpassword123")
-                    - `newPassword` : 새 비밀번호 (예: "newpassword456")                    
+                    - `Authorization: Bearer {accessToken}` : 사용자 인증을 위해 accessToken을 헤더에 포함해야 합니다.          
                                         
                     **응답**
                     - `ApiResponse<Void>`

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/event/AsyncUserEventHandler.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/event/AsyncUserEventHandler.java
@@ -1,0 +1,23 @@
+package com.deepnyangning.capstonebe.domain.user.event;
+
+import com.deepnyangning.capstonebe.external.ai.AiServerClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncUserEventHandler {
+    private final AiServerClient aiServerClient;
+
+    @Async
+    public void sendDeleteRequestToAi(String identifier){
+        try{
+            aiServerClient.sendDeleteFaceToAiServer(identifier, true);
+        } catch (Exception e){
+            log.error("회원 탈퇴 후 AI 서버 얼굴 데이터 삭제 요청 실패: {}", identifier, e);
+        }
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserDeletedEvent.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserDeletedEvent.java
@@ -1,0 +1,11 @@
+package com.deepnyangning.capstonebe.domain.user.event;
+
+import com.deepnyangning.capstonebe.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDeletedEvent {
+    private final User user;
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserEventListener.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserEventListener.java
@@ -1,24 +1,20 @@
 package com.deepnyangning.capstonebe.domain.user.event;
 
 import com.deepnyangning.capstonebe.domain.face.service.FaceDataService;
-import com.deepnyangning.capstonebe.external.ai.AiServerClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class UserEventListener {
     private final FaceDataService faceDataService;
-    private final AiServerClient aiServerClient;
+    private final AsyncUserEventHandler asyncUserEventHandler;
 
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleUserDeleted(UserDeletedEvent event){
-        faceDataService.deleteFaceByUser(event.getUser());
-    }
-
-    @TransactionalEventListener
-    public void handleUserDeletedForAiServer(UserDeletedEvent event){
-        aiServerClient.sendDeleteFaceToAiServer(event.getUser().getIdentifier(), true);
+        faceDataService.deleteFaceByUser(event.getUser()); // 동기
+        asyncUserEventHandler.sendDeleteRequestToAi(event.getUser().getIdentifier()); // 비동기
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserEventListener.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/event/UserEventListener.java
@@ -1,0 +1,24 @@
+package com.deepnyangning.capstonebe.domain.user.event;
+
+import com.deepnyangning.capstonebe.domain.face.service.FaceDataService;
+import com.deepnyangning.capstonebe.external.ai.AiServerClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+    private final FaceDataService faceDataService;
+    private final AiServerClient aiServerClient;
+
+    @TransactionalEventListener
+    public void handleUserDeleted(UserDeletedEvent event){
+        faceDataService.deleteFaceByUser(event.getUser());
+    }
+
+    @TransactionalEventListener
+    public void handleUserDeletedForAiServer(UserDeletedEvent event){
+        aiServerClient.sendDeleteFaceToAiServer(event.getUser().getIdentifier(), true);
+    }
+}

--- a/src/main/java/com/deepnyangning/capstonebe/domain/user/service/UserService.java
+++ b/src/main/java/com/deepnyangning/capstonebe/domain/user/service/UserService.java
@@ -1,12 +1,16 @@
 package com.deepnyangning.capstonebe.domain.user.service;
 
+import com.deepnyangning.capstonebe.domain.face.service.FaceDataService;
 import com.deepnyangning.capstonebe.domain.user.dto.PasswordUpdate;
 import com.deepnyangning.capstonebe.domain.user.entity.Role;
 import com.deepnyangning.capstonebe.domain.user.entity.User;
+import com.deepnyangning.capstonebe.domain.user.event.UserDeletedEvent;
 import com.deepnyangning.capstonebe.domain.user.repository.UserRepository;
+import com.deepnyangning.capstonebe.external.ai.AiServerClient;
 import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ import java.util.List;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
 
     public User findByIdentifier(String identifier){
         return userRepository.findByIdentifier(identifier)
@@ -61,5 +66,6 @@ public class UserService {
     public void deleteUser(String identifier){
         User user = findByIdentifier(identifier);
         user.setActive(false);
+        eventPublisher.publishEvent(new UserDeletedEvent(user));
     }
 }

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
@@ -23,18 +23,19 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class AiServerClient {
-    private static final String AI_SERVER_URL = "https://927a-116-44-51-91.ngrok-free.app/register_face";
+    private static final String AI_SERVER_URL = "https://efba-116-44-51-91.ngrok-free.app";
     private final RestTemplate restTemplate;
 
 
     public String sendFaceDataToAiServer(MultipartFile file, String identifier){
+        String url = AI_SERVER_URL + "/register_face";
         try {
             if (file == null || file.isEmpty()) {
                 log.error("파일이 없거나 비어 있음");
                 throw new CustomException(ErrorCode.INVALID_VIDEO_FILE);
             }
 
-            log.info("파일 전송: URL={}, 이름={}, 크기={}, identifier={}", AI_SERVER_URL, file.getOriginalFilename(), file.getSize(), identifier);
+            log.info("파일 전송: URL={}, 이름={}, 크기={}, identifier={}", url, file.getOriginalFilename(), file.getSize(), identifier);
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -48,7 +49,7 @@ public class AiServerClient {
 
             HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
 
-            ResponseEntity<AiResponse> response = restTemplate.exchange(AI_SERVER_URL, HttpMethod.POST, request, AiResponse.class);
+            ResponseEntity<AiResponse> response = restTemplate.exchange(url, HttpMethod.POST, request, AiResponse.class);
 
             tempFile.delete();
 
@@ -59,7 +60,41 @@ public class AiServerClient {
                 return "FAIL";
             }
         } catch (HttpClientErrorException.NotFound e) {
-            log.error("AI 서버 엔드포인트 없음 (404): URL={}", AI_SERVER_URL, e);
+            log.error("AI 서버 엔드포인트 없음 (404): URL={}", url, e);
+            throw new CustomException(ErrorCode.AI_SERVER_ENDPOINT_NOT_FOUND);
+        } catch (ResourceAccessException e) {
+            log.error("AI 서버 연결 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.AI_SERVER_UNREACHABLE);
+        } catch (Exception e) {
+            log.error("AI 서버 호출 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.AI_SERVER_COMMUNICATION_FAILED);
+        }
+    }
+
+    public String sendDeleteFaceToAiServer(String identifier, boolean removeFolder){
+        String url = AI_SERVER_URL + "/delete_face";
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("identifier", identifier);
+            body.add("remove_folder", String.valueOf(removeFolder)); // true 또는 false 문자열로 전달
+
+            HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("AI 서버 얼굴 삭제 요청 성공: {}", response.getBody());
+                return "SUCCESS";
+            } else {
+                log.warn("AI 서버 얼굴 삭제 실패: 상태={}, 응답={}", response.getStatusCode(), response.getBody());
+                return "FAIL";
+            }
+
+        } catch (HttpClientErrorException.NotFound e) {
+            log.error("AI 서버 엔드포인트 없음 (404): URL={}", url, e);
             throw new CustomException(ErrorCode.AI_SERVER_ENDPOINT_NOT_FOUND);
         } catch (ResourceAccessException e) {
             log.error("AI 서버 연결 실패: {}", e.getMessage(), e);

--- a/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
+++ b/src/main/java/com/deepnyangning/capstonebe/external/ai/AiServerClient.java
@@ -5,6 +5,7 @@ import com.deepnyangning.capstonebe.global.code.ErrorCode;
 import com.deepnyangning.capstonebe.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
@@ -23,7 +24,8 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class AiServerClient {
-    private static final String AI_SERVER_URL = "https://efba-116-44-51-91.ngrok-free.app";
+    @Value("${ai.server-url}")
+    private String AI_SERVER_URL;
     private final RestTemplate restTemplate;
 
 

--- a/src/main/java/com/deepnyangning/capstonebe/global/config/AsyncConfig.java
+++ b/src/main/java/com/deepnyangning/capstonebe/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.deepnyangning.capstonebe.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);      // 최소 2개
+        executor.setMaxPoolSize(4);       // 동시에 실행 가능한 최대 스레드 수
+        executor.setQueueCapacity(10);    // 대기 큐 (탈퇴 요청 많지 않음)
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

회원 탈퇴 시 AI 서버에 얼굴 데이터 삭제 요청 및 DB의 FaceData 삭제 로직 추가

## ➕ 추가/변경된 기능

- AI 서버 요청
- FaceData 삭제
- 이벤트 리스너 - 트랜잭션 커밋 후 실행 보장
- ai 요청 처리는 시간이 소요되어 비동기 처리
- ai 서버 url 관리 방식 변경

## 🗎 관련 이슈

< #51 >